### PR TITLE
Twitter Auth Impementation

### DIFF
--- a/frontend/src/pages/SignIn/SignIn.css
+++ b/frontend/src/pages/SignIn/SignIn.css
@@ -1,13 +1,3 @@
-/* Login.css */
-
-.login-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100vh;
-  }
-  
   .login-title {
     font-size: 24px;
     margin-bottom: 20px;

--- a/frontend/src/pages/SignIn/SignIn.tsx
+++ b/frontend/src/pages/SignIn/SignIn.tsx
@@ -1,44 +1,63 @@
 import React, { useState } from "react";
 import { auth } from "../../firebase";
-import { signInWithPopup, GoogleAuthProvider } from "firebase/auth";
+import { signInWithPopup, GoogleAuthProvider, TwitterAuthProvider } from "firebase/auth";
 import { useLocation } from 'react-router-dom';
 import "./SignIn.css";
 
 const Login: React.FC = () => {
-    const provider = new GoogleAuthProvider();
+    const googleProvider = new GoogleAuthProvider();
+    const twitterProvider = new TwitterAuthProvider();
     const location = useLocation();
     const nickname = (location.state as { nickname?: string })?.nickname || 'User';
     
-    // State to track if user is authenticated
     const [isAuthenticated, setIsAuthenticated] = useState(false);
+    const [loginProvider, setLoginProvider] = useState<string | null>(null);
 
     const handleGoogleSignIn = () => {
-        signInWithPopup(auth, provider)
-        .then((result) => {
-            const user = result.user;
-            console.log("User: ", user);
-            // Set authenticated state to true
-            setIsAuthenticated(true);
-        }).catch((error) => {
-            console.log("Error: ", error);
-        });
+        signInWithPopup(auth, googleProvider)
+            .then((result) => {
+                const user = result.user;
+                console.log("User (Google): ", user);
+                setIsAuthenticated(true);
+                setLoginProvider("Google");
+            }).catch((error) => {
+                console.log("Google Sign-in Error: ", error);
+            });
+    };
+
+    const handleTwitterSignIn = () => {
+        signInWithPopup(auth, twitterProvider)
+            .then((result) => {
+                const user = result.user;
+                console.log("User (Twitter): ", user);
+                setIsAuthenticated(true);
+                setLoginProvider("Twitter");
+            }).catch((error) => {
+                console.log("Twitter Sign-in Error: ", error);
+            });
     };
 
     return (
         <div className="login-container">
-            <h2 className="login-title">Login with Google</h2>
+            <h2 className="login-title">Login</h2>
             {!isAuthenticated && (
                 <div>
-                <h1>Welcome, {nickname}!</h1>
-                    <button className="login-button" onClick={handleGoogleSignIn}>
+                    <h1>Welcome, {nickname}!</h1>
+                    <p>Please choose one of the options below to sign in:</p>
+                    <button className="login-button google-button" onClick={handleGoogleSignIn}>
                         Sign in with Google
                     </button>
+                    <br></br>
+                    <h3>or</h3>
+                    <button className="login-button twitter-button" onClick={handleTwitterSignIn}>
+                        Sign in with Twitter
+                    </button>
                 </div>
+            
             )}
-            {/* Display something if the user is authenticated with Google */}
             {isAuthenticated && (
                 <div className="welcome-message">
-                    <h3>You are successfully logged in!</h3>
+                    <h3>You are successfully logged in with {loginProvider}!</h3>
                     <p>Enjoy your stay, {nickname}!</p>
                 </div>
             )}

--- a/frontend/src/pages/UserInfo/UserInfoForm.tsx
+++ b/frontend/src/pages/UserInfo/UserInfoForm.tsx
@@ -58,7 +58,7 @@ const UserInfo: React.FC = () => {
   // Handles user confirmation in the modal and navigates to the next page
   const handleConfirm = () => {
     setShowModal(false); // Close the modal
-    navigate('/sign-in', { state: { nickname } }); // Navigate to the next page
+    navigate('/sign-in', { state: { nickname } }); //navigate to next page and pass nickname as state
   };
 
   // Handles cancellation in the modal, keeping the user on the same page


### PR DESCRIPTION
1. Implented Twitter sign-in option alongside the existing Google sign-in, giving users more flexibility in their login method. 
2. Each provider has its own button, making the options visually distinct on the sign in page

the user has to click sign in through twitter in order to log in using twitter
![Screenshot 2024-11-04 at 1 36 10 PM](https://github.com/user-attachments/assets/8a34c6f8-359c-49af-94d8-e7d799b87a47)
the user can see that they have logged in through twitter since their auth is successful on the frontend
![Screenshot 2024-11-04 at 1 37 45 PM](https://github.com/user-attachments/assets/75a79bbc-1f36-446c-9b00-d5d3e6f9590d)
the uid is created when the user auth using twitter is successful
![Screenshot 2024-11-04 at 1 37 42 PM](https://github.com/user-attachments/assets/0015698b-0937-4353-a214-d7cf35946fbc)
On firebase, we can see that the user is there
![Screenshot 2024-11-04 at 1 37 50 PM](https://github.com/user-attachments/assets/ad15b5ad-f302-4a8b-a339-c901b022ef48)
