### PR TITLE
/addUnknowns endpoint functionality.

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -19,11 +19,13 @@ app.use(express.json());
 const currentStateRoute = require('./routes/currentState');
 const resetCourtsRoute = require('./routes/resetCourts');
 const expectedWaitTimeRoute = require('./routes/expectedWaitTime');
+const addUnknownsRoute = require('./routes/addUnknowns');
 
 // Use imported routes
 app.use('/api', currentStateRoute);  // currentState endpoint
 app.use('/api', resetCourtsRoute);  // resetCourts endpoint
 app.use('/api', expectedWaitTimeRoute);  // expectedWaitTime endpoint
+app.use('/api', addUnknownsRoute);  // addUnknowns endpoint
 
 // Default route
 app.get('/', (req, res) => {

--- a/backend/routes/addUnknowns.js
+++ b/backend/routes/addUnknowns.js
@@ -80,8 +80,8 @@ router.post('/addUnknowns', async (req, res) => {
     res.status(200).send({ success: 'Updated court information.' });
 
   } catch (error) {
-    console.error('Error in currentState endpoint: ', error);
-    res.status(500).send({ error: 'Failed to retrieve current state.' });
+    console.error('Error in addUnknowns endpoint: ', error);
+    res.status(500).send({ error: 'Failed to add unknowns.' });
   }
 });
 

--- a/backend/routes/addUnknowns.js
+++ b/backend/routes/addUnknowns.js
@@ -1,0 +1,96 @@
+const express = require('express');
+const router = express.Router();
+const admin = require('firebase-admin');
+
+// Add Unknowns Endpoint
+router.post('/addUnknowns', async (req, res) => {
+  try {
+    // Extract location and occupied courts from the request body
+    const { location, occupiedCourts } = req.body;
+    if (!location || !Array.isArray(occupiedCourts)) {
+      return res.status(400).json({ message: 'Location and occupied court information is required.' });
+    }
+
+    // Retrieve active court information for the given location
+    const activePlayersSnapshot = await admin.firestore()
+      .collection('locations')
+      .doc(location)
+      .collection('activePlayers')
+      .orderBy('courtNumber')
+      .get();
+
+    // Check for empty active player snapshot (as always filled with Empty/Unknown/Player objects)
+    if (activePlayersSnapshot.empty) {
+      return res.status(404).json({ message: 'Invalid location.' });
+    }
+
+    // Creating shuffled timestamp adjustments
+    const now = new Date();
+    const adjustments = [-40, -30, -20, -10, 0];
+    const timestamps = adjustments.map(seconds => {
+      const adjustedTime = new Date(now);
+      adjustedTime.setSeconds(now.getSeconds() + seconds);
+      return adjustedTime;
+    });
+    shuffleArray(timestamps);
+    let lastTimestampIdx = 0;
+
+    // Update each document based on user information
+    const batch = admin.firestore().batch();
+    activePlayersSnapshot.docs.forEach(doc => {
+      const courtNumber = doc.data().courtNumber;
+      const isOccupied = occupiedCourts.includes(courtNumber);
+      const isEmptyCourt = doc.data().firebaseUID.startsWith('Empty');
+
+      // If court is occupied, check if it's shown as empty
+      if (isOccupied) {
+        if (isEmptyCourt) {
+          const newName = `Unknown${courtNumber}`;
+          const timestamp = timestamps[lastTimestampIdx];
+          lastTimestampIdx += 1;
+
+          const updateObj = {
+            playerWaiting: false,
+            firebaseUID: newName,
+            nickname: newName,
+            timeStartedPlay: timestamp,
+          };
+
+          batch.set(doc.ref, updateObj, { merge: true });
+        }
+
+      // If court is empty, check if it's shown as occupied
+      } else {
+        if (!isEmptyCourt) {
+          const newName = `Empty${courtNumber}`;
+
+          const updateObj = {
+            playerWaiting: false,
+            firebaseUID: newName,
+            nickname: newName,
+          };
+
+          batch.set(doc.ref, updateObj, { merge: true });
+        }
+      }
+    });
+
+    // Commit batch and send success response to client
+    await batch.commit();
+    res.status(200).send({ success: 'Updated court information.' });
+
+  } catch (error) {
+    console.error('Error in currentState endpoint: ', error);
+    res.status(500).send({ error: 'Failed to retrieve current state.' });
+  }
+});
+
+// Creating shuffle function
+const shuffleArray = (array) => {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));  // Random index
+    [array[i], array[j]] = [array[j], array[i]];  // Swap elements
+  }
+};
+
+module.exports = router;


### PR DESCRIPTION
Here is the state of the courts before the endpoint:

<img width="796" alt="1-Old" src="https://github.com/user-attachments/assets/99bf59f4-3e73-43a5-bc39-2025ca15e60a">

<img width="793" alt="2-Old" src="https://github.com/user-attachments/assets/d0c1a1fc-df1c-4591-a9ba-79576e4ec549">

<img width="792" alt="3-Old" src="https://github.com/user-attachments/assets/137c223c-39bc-4c41-97ec-3067e0d32ec0">

<img width="801" alt="4-Old" src="https://github.com/user-attachments/assets/d254e4e3-0932-402d-9d56-9c1cd52de490">

You can see that courts 1 & 3 are empty, and courts 2 & 4 are occupied.

Now, we call the endpoint. We inform the backend that courts 1,2 and 3 are occupied. This means courts 1 and 3 should now have unknown names. Court 2 should stay the same. Lastly, court 4 should reset to empty.

<img width="763" alt="Postman" src="https://github.com/user-attachments/assets/22f50e39-6e52-4eef-ad5a-21c3f1971feb">

We can see the changes reflected in Firestore:
<img width="796" alt="1-New" src="https://github.com/user-attachments/assets/b7b4aab2-a6ea-485b-855b-172e2f8ab6f5">

<img width="825" alt="2-New" src="https://github.com/user-attachments/assets/18c4ba2f-a850-470a-8a07-65e20aa62eb3">

<img width="806" alt="3-New" src="https://github.com/user-attachments/assets/31c1518a-187f-4e01-ae2f-86dbc12dae97">

<img width="833" alt="4-New" src="https://github.com/user-attachments/assets/b2b6a9ad-d486-47c0-be8a-a3bb40ae152d">

Note how the timestamps for 1 and 3 have changed to time of the endpoint request with the random adjustment. Also, note how the difference in their timestamps is 20 seconds, which could have arisen from a -40, -20 / -30, -10 / -20, 0 adjustment selection.