### PR TITLE
getTaken Endpoint

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -22,6 +22,7 @@ const expectedWaitTimeRoute = require('./routes/expectedWaitTime');
 const addUnknownsRoute = require('./routes/addUnknowns');
 const leaveQueueRoute = require('./routes/leaveQueue');
 const endSessionRoute = require('./routes/endSession');
+const getTakenRoute = require('./routes/getTaken');
 
 // Use imported routes
 app.use('/api', currentStateRoute);  // currentState endpoint
@@ -30,6 +31,7 @@ app.use('/api', expectedWaitTimeRoute);  // expectedWaitTime endpoint
 app.use('/api', addUnknownsRoute);  // addUnknowns endpoint
 app.use('/api', leaveQueueRoute);  // leaveQueue endpoint
 app.use('/api', endSessionRoute);  // endSession endpoint
+app.use('/api', getTakenRoute);  // getTaken endpoint
 
 // Default route
 app.get('/', (req, res) => {

--- a/backend/routes/getTaken.js
+++ b/backend/routes/getTaken.js
@@ -1,0 +1,67 @@
+const express = require('express');
+const router = express.Router();
+const admin = require('firebase-admin');
+
+// Get Taken Courts Endpoint
+router.post('/getTaken', async (req, res) => {
+  try {
+    // Extract location from the request body
+    // if location is not provided, return 400 status code with message
+    const { location } = req.body;
+    if (!location) {
+      return res.status(400).json({ message: 'Location is required.' });
+    }
+
+    // Retrieve active player information for the given location and store it in activePlayersSnapshot
+    const activePlayersSnapshot = await admin.firestore()
+      .collection('locations')
+      .doc(location)
+      .collection('activePlayers')
+      .get();
+
+    // Check for empty active player snapshot
+    if (activePlayersSnapshot.empty) {
+      return res.status(404).json({ message: 'Invalid location.' });
+    }
+
+    // Check for a queue in the location and store it in queueSnapshot
+    const queueSnapshot = await admin.firestore()
+      .collection('locations')
+      .doc(location)
+      .collection('queuePlayers')
+      .get();
+
+    // If there are entries in the queue, no update is required, return 200 status code with updateRequired as false
+    if (!queueSnapshot.empty) {
+      return res.status(200).json({
+        updateRequired: false
+      });
+    }
+
+    // Otherwise, return court information where firebaseUID doesn't start with 'Empty'
+    const takenCourts = [];
+    let numberOfCourts = 0;
+
+    activePlayersSnapshot.forEach(doc => {
+      const firebaseUID = doc.data().firebaseUID;
+      const courtNumber = doc.data().courtNumber;
+
+      if (!firebaseUID.startsWith('Empty')) {
+        takenCourts.push(courtNumber);
+        numberOfCourts++;
+      }
+    });
+
+    return res.status(200).json({
+      takenCourts: takenCourts,
+      numberOfCourts: numberOfCourts,
+      updateRequired: true
+    });
+
+  } catch (error) {
+    console.error('Error in getTaken endpoint: ', error);
+    res.status(500).send({ error: 'Failed to get taken courts.' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
# Court Occupancy API

This API provides endpoints to manage and retrieve information about court occupancy. The key functionality of this API includes checking the status of courts, determining whether they are occupied, and providing updates when necessary.

## API Endpoints

```/getTaken``` - Get Info on Taken Courts

#### **Description**
This endpoint retrieves information about the courts that are currently occupied based on a given location. If there are players waiting in the queue, it returns a flag indicating no update is required. Otherwise, it returns the court numbers of the occupied courts, along with the total count and an update flag.

#### **HTTP Method:**
- `POST`

#### **Request Body:**
```json
{
  "location": "Cassie Campbell"
}
```

### API Responses

- **Screenshot 1: Queue Not Empty**
<img width="1038" alt="Screenshot 2024-11-14 at 12 14 12 AM" src="https://github.com/user-attachments/assets/537d8db2-9a4f-4bb0-a5da-e44b5c95faae">

- **Screenshot 2: Queue is Empty**
<img width="1042" alt="Screenshot 2024-11-14 at 12 13 35 AM" src="https://github.com/user-attachments/assets/55c6e790-04f9-477d-8c5c-52556feeaff7">