### PR TITLE
Revamp current state and active view to use new database structure…

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -21,6 +21,8 @@ const expectedWaitTimeRoute = require('./routes/expectedWaitTimeRoute');
 const addUnknownsRoute = require('./routes/addUnknownsRoute');
 const leaveQueueRoute = require('./routes/leaveQueueRoute');
 const endSessionRoute = require('./routes/endSessionRoute');
+const currentStateRoute = require('./routes/currentStateRoute');
+const joinGameRoute = require('./routes/joinGameRoute');
 
 // Use imported routes
 app.use('/api', resetCourtsRoute);  // resetCourts endpoint
@@ -28,6 +30,8 @@ app.use('/api', expectedWaitTimeRoute);  // expectedWaitTime endpoint
 app.use('/api', addUnknownsRoute);  // addUnknowns endpoint
 app.use('/api', leaveQueueRoute);  // leaveQueue endpoint
 app.use('/api', endSessionRoute);  // endSession endpoint
+app.use('/api', currentStateRoute); // currentState endpoint
+app.use('/api', joinGameRoute); // DUMMY joinGame endpoint - REPLACE WITH ACTUAL CODE IN ROUTE FILE!
 
 // Default route
 app.get('/', (req, res) => {

--- a/backend/routes/currentStateRoute.js
+++ b/backend/routes/currentStateRoute.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const router = express.Router();
+const admin = require('firebase-admin');
+
+// Current State Endpoint
+router.post('/currentState', async (req, res) => {
+    try {
+        // Extract location from the request body
+        const { location } = req.body;
+        if (!location) {
+          return res.status(400).json({ message: 'Location is required.' });
+        }
+
+        // Get the location document snapshot
+        const locationRef = admin.firestore().collection('locations').doc(location);
+        const locationSnapshot = await locationRef.get();
+        if (!locationSnapshot.exists) {
+            return res.status(404).json({ message: 'Location not found.' });
+        }
+
+        // Access relevant arrays
+        const locationData = locationSnapshot.data();
+        const { queueFirebaseUIDs, queueNicknames, activeFirebaseUIDs, activeNicknames } = locationData;
+
+        // Send response back to client with updated player arrays
+        res.status(200).json({
+          activeNicknames: activeNicknames,
+          queueNicknames: queueNicknames,
+          activeFirebaseUIDs: activeFirebaseUIDs,
+          queueFirebaseUIDs: queueFirebaseUIDs
+        });
+
+    } catch (error) {
+        console.error('Error in currentState endpoint: ', error);
+        res.status(500).send({ error: 'Failed to retrieve current state.' });
+    }
+});
+
+module.exports = router;

--- a/backend/routes/joinGameRoute.js
+++ b/backend/routes/joinGameRoute.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const router = express.Router();
+const admin = require('firebase-admin');
+
+// DUMMY - Join Game Endpoint
+/* ONLY FOR TESTING PURPOSES DO NOT USE! 
+Wrong becase:
+- Only adds to queue
+- Does NOT use modular style
+- Does NOT use transaction
+- Does NOT add to active and set start time and player waiting false for active
+- Does NOT check MAX BOUND of 5 queue size
+*/
+router.post('/joinGame', async (req, res) => {
+    try {
+        // Extract location, nickname and firebaseUID from the request body
+        const { location, nickname, firebaseUID } = req.body;
+        if (!location || !firebaseUID || firebaseUID.toLowerCase().startsWith("empty")) {
+            return res.status(400).json({ message: 'Location and Firebase UID are required.' });
+        }
+
+        // Get the location document snapshot
+        const locationRef = admin.firestore().collection('locations').doc(location);
+        const locationSnapshot = await locationRef.get();
+        if (!locationSnapshot.exists) {
+            return res.status(404).json({ message: 'Location not found.' });
+        }
+
+        // Access relevant arrays
+        const locationData = locationSnapshot.data();
+        const { queueFirebaseUIDs, queueNicknames } = locationData;
+
+        // Add player to end of queue
+        queueFirebaseUIDs.push(firebaseUID);
+        queueNicknames.push(nickname);
+
+        // Write new data to Firestore
+        await locationRef.update({
+            queueFirebaseUIDs: queueFirebaseUIDs,
+            queueNicknames: queueNicknames,
+        });
+  
+        res.status(200).json({ status: 'queue' });
+    } catch (error) {
+        console.error('Error joining game:', error);
+        res.status(500).json({ error: 'Failed to join game.' });
+    }
+});
+  
+module.exports = router;

--- a/frontend/src/pages/ActiveView/ConfirmationModal.css
+++ b/frontend/src/pages/ActiveView/ConfirmationModal.css
@@ -1,0 +1,73 @@
+/* Full-screen overlay for the modal */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent background */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+  }
+  
+  /* Modal content box */
+  .modal-content {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    width: 300px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+    text-align: center;
+  }
+  
+  /* Modal message */
+  .modal-content h2 {
+    margin-bottom: 10px;
+    font-size: 20px;
+    color: #333;
+  }
+  
+  .modal-content p {
+    font-size: 16px;
+    color: #555;
+    margin-bottom: 20px;
+  }
+  
+  /* Buttons for confirmation and cancellation */
+  .modal-buttons {
+    display: flex;
+    justify-content: space-around;
+  }
+  
+  .modal-confirm-button {
+    padding: 10px 20px;
+    background-color: #007bff;
+    color: #fff;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-weight: bold;
+    transition: background-color 0.3s ease;
+  }
+  
+  .modal-confirm-button:hover {
+    background-color: #0056b3;
+  }
+  
+  .modal-cancel-button {
+    padding: 10px 20px;
+    background-color: #ccc;
+    color: #333;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-weight: bold;
+    transition: background-color 0.3s ease;
+  }
+  
+  .modal-cancel-button:hover {
+    background-color: #999;
+  }
+  

--- a/frontend/src/pages/ActiveView/ConfirmationModal.tsx
+++ b/frontend/src/pages/ActiveView/ConfirmationModal.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import './ConfirmationModal.css';
+
+interface ConfirmationModalProps {
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmationModal: React.FC<ConfirmationModalProps> = ({ message, onConfirm, onCancel }) => {
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content">
+        <h2>Confirm Action</h2>
+        <p>{message}</p>
+        <div className="modal-buttons">
+          <button onClick={onConfirm} className="modal-confirm-button">Confirm</button>
+          <button onClick={onCancel} className="modal-cancel-button">Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmationModal;

--- a/frontend/src/pages/ActiveView/PlayerList.css
+++ b/frontend/src/pages/ActiveView/PlayerList.css
@@ -1,46 +1,50 @@
+@media (max-width: 768px) {
+  .courts {
+    flex-direction: column; /* Stack players vertically on small screens */
+  }
+
+  h2 {
+    font-size: 1.2em; /* Slightly smaller headings for compact screens */
+  }
+}
+
 .player-list {
-  padding: 16px;
+  padding: 20px;
   font-family: Arial, sans-serif;
 }
 
 h2 {
   font-size: 1.5em;
   margin-bottom: 10px;
+  color: #333;
+}
+
+.active-players,
+.queue-players {
+  margin-bottom: 20px;
 }
 
 .courts {
   display: flex;
-  justify-content: space-between;
-  margin-bottom: 20px;
-}
-
-.court {
-  background-color: #007bff;
-  color: white;
-  border-radius: 8px;
-  padding: 20px;
-  flex: 1;
-  margin: 0 5px; /* Space between courts */
-  text-align: center;
-  min-width: 60px; /* Ensures minimum size */
-}
-
-.queue-players {
-  background-color: #f8f9fa;
-  border-radius: 8px;
+  flex-wrap: wrap; /* Allow items to wrap into the next line */
+  gap: 10px; /* Space between rectangles */
+  background-color: #f8f9fa; /* Light background for the active players section */
   padding: 10px;
+  border-radius: 8px;
 }
 
-.queue-players ul {
-  list-style: none;
-  padding: 0;
+.queue-list {
+  display: flex;
+  flex-direction: column; /* Stack players vertically */
+  gap: 10px; /* Space between rectangles */
+  background-color: #f8f9fa; /* Light background for the queue players section */
+  padding: 10px;
+  border-radius: 8px;
 }
 
-.queue-players li {
-  padding: 5px;
-  border-bottom: 1px solid #e9ecef;
-}
-
-.queue-players li:last-child {
-  border-bottom: none;
+p {
+  margin: 0;
+  font-size: 1em;
+  color: #666;
+  text-align: center;
 }

--- a/frontend/src/pages/ActiveView/PlayerList.tsx
+++ b/frontend/src/pages/ActiveView/PlayerList.tsx
@@ -1,17 +1,31 @@
-import React from 'react';
-import './PlayerList.css';
+import React from "react";
+import RectangleWithOptions from "./RectangleWithOptions";
+import "./PlayerList.css";
 
 interface PlayerListProps {
   activePlayers: string[];
   queuePlayers: string[];
+  activeFirebaseUIDs: string[];
+  queueFirebaseUIDs: string[];
+  userFirebaseUID: string;
+  userInQueue: boolean;
+  location: string;
 }
 
-const PlayerList: React.FC<PlayerListProps> = ({ activePlayers, queuePlayers }) => {
+const PlayerList: React.FC<PlayerListProps> = ({
+  activePlayers,
+  queuePlayers,
+  activeFirebaseUIDs,
+  queueFirebaseUIDs,
+  userFirebaseUID,
+  userInQueue,
+  location,
+}) => {
   // Function to clean up nicknames
   const formatNickname = (nickname: string) => {
-    if (!nickname) return 'Unknown'; // Handle null or undefined values
-    if (nickname.startsWith('Unknown')) return 'Unknown';
-    if (nickname.startsWith('Empty')) return 'Empty';
+    if (!nickname) return "Player"; // Handle null or undefined values
+    if (nickname.startsWith("Unknown")) return "Unknown";
+    if (nickname.startsWith("Empty")) return "Empty";
     return nickname;
   };
 
@@ -21,23 +35,37 @@ const PlayerList: React.FC<PlayerListProps> = ({ activePlayers, queuePlayers }) 
         <h2>Active Players</h2>
         <div className="courts">
           {activePlayers.map((nickname, index) => (
-            <div className="court" key={index}>
-              {formatNickname(nickname)}
-            </div>
+            <RectangleWithOptions
+              key={index}
+              nickname={formatNickname(nickname)}
+              firebaseUID={activeFirebaseUIDs[index]}
+              userFirebaseUID={userFirebaseUID}
+              userInQueue={userInQueue}
+              inQueue={false}
+              location={location}
+            />
           ))}
         </div>
       </div>
       <div className="queue-players">
         <h2>Queue Players</h2>
-        <ul>
+        <div className="queue-list">
           {queuePlayers.length > 0 ? (
             queuePlayers.map((nickname, index) => (
-              <li key={index}>{formatNickname(nickname)}</li>
+              <RectangleWithOptions
+                key={index}
+                nickname={formatNickname(nickname)}
+                firebaseUID={queueFirebaseUIDs[index]}
+                userFirebaseUID={userFirebaseUID}
+                userInQueue={userInQueue}
+                inQueue={true}
+                location={location}
+              />
             ))
           ) : (
-            <li>No players in the queue.</li>
+            <p>No players in the queue.</p>
           )}
-        </ul>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/ActiveView/RectangleWithOptions.css
+++ b/frontend/src/pages/ActiveView/RectangleWithOptions.css
@@ -1,0 +1,55 @@
+.rectangle-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px;
+  margin: 10px 0;
+  background-color: #f0f0f0;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  position: relative;
+  flex: 1 1 20%; /* Each rectangle will take up 20% of the available width */
+  box-sizing: border-box; /* Ensure padding is included in the width calculation */
+}
+
+.dots-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  height: 16px;
+  cursor: pointer;
+  margin-left: 10px;
+}
+
+.dot {
+  width: 4px;
+  height: 4px;
+  background-color: #333;
+  border-radius: 50%;
+}
+
+.action-button {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  margin-top: 5px; /* Position the button right below the rectangle */
+  padding: 5px 10px;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.action-button:hover {
+  background-color: #0056b3;
+}
+
+.button-container {
+  display: flex;
+  gap: 10px; /* Space between buttons */
+  position: absolute;
+  top: 100%; /* Position below the rectangle */
+  left: 0;
+}

--- a/frontend/src/pages/ActiveView/RectangleWithOptions.tsx
+++ b/frontend/src/pages/ActiveView/RectangleWithOptions.tsx
@@ -1,0 +1,166 @@
+import React, { useState, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";  // For navigation
+import { leaveQueue, endSession } from "../../utils/api";  // Import utility functions
+import ConfirmationModal from "./ConfirmationModal";  // Import modal
+import "./RectangleWithOptions.css";
+
+interface RectangleWithOptionsProps {
+  nickname: string;
+  firebaseUID: string;
+  userFirebaseUID: string;
+  userInQueue: boolean;
+  inQueue: boolean;
+  location: string;
+}
+
+// Button text constants
+const BUTTON_TEXT = {
+  OWN_SESSION: "End your session?",
+  IN_QUEUE: "Leave the queue?",
+  LEFT_EARLY: "No-show? / Player left early?"
+};
+
+const RectangleWithOptions: React.FC<RectangleWithOptionsProps> = ({
+  nickname,
+  firebaseUID,
+  userFirebaseUID,
+  userInQueue,
+  inQueue,
+  location,
+}) => {
+  const [showButton, setShowButton] = useState(false);
+  const [showModal, setShowModal] = useState(false);  // Track modal visibility
+  const [actionToConfirm, setActionToConfirm] = useState("");  // Track the action to confirm
+  const buttonRef = useRef(null);
+  const rectangleRef = useRef(null);
+  const navigate = useNavigate();  // Hook to navigate to other routes
+
+  // Determines if the button text should change based on user comparison
+  const determineButtonText = () => {
+    if (userFirebaseUID === firebaseUID) {
+      return inQueue ? BUTTON_TEXT.IN_QUEUE : BUTTON_TEXT.OWN_SESSION;
+    } else {
+      return BUTTON_TEXT.LEFT_EARLY;
+    }
+  };
+
+  // Handles clicks outside of the rectangle and button to close the button if clicked outside
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      rectangleRef.current &&
+      !rectangleRef.current.contains(event.target) &&
+      buttonRef.current &&
+      !buttonRef.current.contains(event.target)
+    ) {
+      setShowButton(false);
+    }
+  };
+
+  // Determines if the button should be ignored based on the UID and queue status
+  const shouldIgnoreButton = () => {
+    return (
+      firebaseUID.startsWith("Empty") ||  // Ignore empty courts
+      (inQueue && firebaseUID !== userFirebaseUID) ||  // Ignore queue for other players
+      (!userInQueue && firebaseUID !== userFirebaseUID)  // If user is active, ignore everything except their own court
+    );
+  };
+
+  // Handle button click event for leaving the queue or ending session
+  const handleButtonClick = () => {
+    if (userFirebaseUID === firebaseUID) {
+      if (inQueue) {
+        setActionToConfirm("leaveQueue");
+      } else {
+        setActionToConfirm("endSession");
+      }
+      setShowModal(true);
+    } else {
+      setActionToConfirm("endOtherSession");
+      setShowModal(true);
+    }
+  };
+
+  // Handle modal confirmation (Leave Queue or End Session)
+  const handleConfirm = async () => {
+    try {
+      if (actionToConfirm === "leaveQueue") {
+        await leaveQueue(location, firebaseUID);  // User is leaving the queue
+        alert("You have left the queue.");
+      } else if (actionToConfirm === "endSession") {
+        await endSession(location, firebaseUID);  // User is ending their own session
+        alert("Session ended.");
+      } else if (actionToConfirm === "endOtherSession") {
+        await endSession(location, firebaseUID);  // Force others to end their session
+        alert("Player session ended.");
+      }
+
+      // Close the modal first
+      setShowModal(false);  
+
+      // Navigate only if the action was related to the user's own session or leaving the queue
+      if (actionToConfirm === "leaveQueue" || actionToConfirm === "endSession") {
+        setTimeout(() => {
+          localStorage.clear();  // Clear local storage
+          navigate("/");  // After closing the modal, navigate to the home page
+        }, 300); // Optional: small delay to ensure smooth transition
+      }
+    } catch (error) {
+      console.log("Error: " + error.message);
+    }
+  };
+
+  // Handle modal cancelation
+  const handleCancel = () => {
+    setShowModal(false);  // Close the modal without taking any action
+  };
+
+  // Set up event listener to handle outside clicks
+  useEffect(() => {
+    document.addEventListener("click", handleClickOutside);
+    return () => {
+      document.removeEventListener("click", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div ref={rectangleRef} className="rectangle-container">
+      <span>{nickname}</span>
+
+      {/* Display dots for toggling the button */}
+      {!shouldIgnoreButton() && (
+        <>
+          <div
+            className="dots-container"
+            onClick={() => setShowButton((prev) => !prev)}
+          >
+            <div className="dot"></div>
+            <div className="dot"></div>
+            <div className="dot"></div>
+          </div>
+
+          {/* Conditionally render the button */}
+          {showButton && (
+            <button
+              ref={buttonRef}
+              className="action-button"
+              onClick={handleButtonClick}
+            >
+              {determineButtonText()}
+            </button>
+          )}
+        </>
+      )}
+
+      {/* Confirmation Modal */}
+      {showModal && (
+        <ConfirmationModal
+          message="Are you sure?"
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      )}
+    </div>
+  );
+};
+
+export default RectangleWithOptions;

--- a/frontend/src/pages/LocationSelection/LocationSelection.tsx
+++ b/frontend/src/pages/LocationSelection/LocationSelection.tsx
@@ -4,13 +4,11 @@ import './LocationSelection.css';
 
 const LocationSelection: React.FC = () => {
   // Sample locations list
-  const locations = ["Cassie Campbell", "Option 1", "Option 2"];
+  const locations = ["Cassie Campbell"];
 
   // State to store the selected location
   // Use this state to access the user selected location for queue purposes
-  // By default, select the first location (Cassie Campbell)
-  const [selectedLocation, setSelectedLocation] = useState<string>(locations[0]);
-
+  const [selectedLocation, setSelectedLocation] = useState<string>('');
 
   // Hook for navigating to the next page
   const navigate = useNavigate();
@@ -48,7 +46,7 @@ const LocationSelection: React.FC = () => {
         value={selectedLocation}
         onChange={handleLocationChange}
       >
-        <option value="" disabled>Select From...</option>
+        <option value="">Select From...</option>
         {locations.map((location, index) => (
           <option key={index} value={location}>
             {location}

--- a/frontend/src/pages/SignIn/SignIn.tsx
+++ b/frontend/src/pages/SignIn/SignIn.tsx
@@ -19,6 +19,7 @@ const Login: React.FC = () => {
     const navigate = useNavigate();
 
     const handleGoogleSignIn = () => {
+        localStorage.setItem("addedToGame", "false");
         signInWithPopup(auth, provider)
         .then((result) => {
             const user = result.user;
@@ -26,6 +27,7 @@ const Login: React.FC = () => {
             // Set authenticated state to true
             setIsAuthenticated(true);
             localStorage.setItem("firebaseUID", user.uid);
+            setTimeout(() => {}, 1000);
             navigate('/active-view'); // Navigate to the next page
         }).catch((error) => {
             console.log("Error: ", error);


### PR DESCRIPTION
Revamp current state and active view to use new database structure and add player objects to directly call end session and leave queue.
- As mentioned in design and in other PR, listeners are only for queue players as active players don't need or care about updates in the queue or anywhere else.

Please see the below screenshots to better understand the changes. *Click on each picture to view properly.

"No-Show? / Left Early?" button for non-empty active players:
<img width="1512" alt="No-Show : Left Early" src="https://github.com/user-attachments/assets/c4110e14-4a78-4e88-bd5b-b5c9ba8dcba8">

Listener showing change in queue player's nickname:
<img width="1512" alt="Handle Update" src="https://github.com/user-attachments/assets/ef8b4ba2-f856-44af-9e44-7bd5d414b7ad">

Switch player to active (note the value of inQueue in local storage)
<img width="1512" alt="Switch to Active" src="https://github.com/user-attachments/assets/ebc80719-367b-40de-bf50-fb5ff7936e4d">

The next 4 screenshots show what happens when the user leaves queue:
1. Click Button
<img width="1512" alt="Leave Queue" src="https://github.com/user-attachments/assets/26771cd2-8d2d-4ffc-842f-b24acddf20da">

2. Confirmation Modal
<img width="1512" alt="LQ2" src="https://github.com/user-attachments/assets/157fd383-d547-462d-bac6-970b75866d5b">

3. Alert Message
<img width="1512" alt="LQ3" src="https://github.com/user-attachments/assets/0ca17408-7eac-4819-9f65-bd1bf243672e">

4. Local Storage Clear & Navigate to Home
<img width="1512" alt="LQ4" src="https://github.com/user-attachments/assets/dcdb542f-26f9-4a8c-a11a-e9eb49897e93">