### PR TITLE
getTaken endpoint

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -21,6 +21,7 @@ const expectedWaitTimeRoute = require('./routes/expectedWaitTimeRoute');
 const addUnknownsRoute = require('./routes/addUnknownsRoute');
 const leaveQueueRoute = require('./routes/leaveQueueRoute');
 const endSessionRoute = require('./routes/endSessionRoute');
+const getTakenRoute = require('./routes/getTakenRoute');
 
 // Use imported routes
 app.use('/api', resetCourtsRoute);  // resetCourts endpoint
@@ -28,6 +29,7 @@ app.use('/api', expectedWaitTimeRoute);  // expectedWaitTime endpoint
 app.use('/api', addUnknownsRoute);  // addUnknowns endpoint
 app.use('/api', leaveQueueRoute);  // leaveQueue endpoint
 app.use('/api', endSessionRoute);  // endSession endpoint
+app.use('/api', getTakenRoute); // getTaken endpoint
 
 // Default route
 app.get('/', (req, res) => {

--- a/backend/routes/getTakenRoute.js
+++ b/backend/routes/getTakenRoute.js
@@ -25,12 +25,9 @@ router.post('/getTaken', async (req, res) => {
 
     // Get active players from the location data
     const activePlayers = locationData.activeFirebaseUIDs;
-    console.log(activePlayers);
 
     // Get queue players from the location data
     const queuePlayers = locationData.queueFirebaseUIDs;
-    console.log(queuePlayers);
-    console.log(queuePlayers.length);
 
     // If there are entries in the queue, no update is required, return 200 status code with updateRequired as false
     if (queuePlayers.length > 0) {

--- a/backend/routes/getTakenRoute.js
+++ b/backend/routes/getTakenRoute.js
@@ -25,17 +25,15 @@ router.post('/getTaken', async (req, res) => {
 
     // Get active players from the location data
     const activePlayers = locationData.activeFirebaseUIDs;
+    console.log(activePlayers);
 
     // Get queue players from the location data
     const queuePlayers = locationData.queueFirebaseUIDs;
-
-    // Check for empty active player snapshot
-    if (activePlayers.empty) {
-      return res.status(404).json({ message: 'Invalid location.' });
-    }
+    console.log(queuePlayers);
+    console.log(queuePlayers.length);
 
     // If there are entries in the queue, no update is required, return 200 status code with updateRequired as false
-    if (!queuePlayers.empty) {
+    if (queuePlayers.length > 0) {
       return res.status(200).json({
         updateRequired: false
       });

--- a/backend/routes/getTakenRoute.js
+++ b/backend/routes/getTakenRoute.js
@@ -1,0 +1,69 @@
+const express = require('express');
+const router = express.Router();
+const admin = require('firebase-admin');
+
+// Get Taken Courts Endpoint
+router.post('/getTaken', async (req, res) => {
+  try {
+    // Get the location from the request body and validate
+    const location = req.body.location;
+    if (!location) {
+        return res.status(400).json({ message: "Location is required" });
+    }
+
+    // Get the location document snapshot
+    const locationRef = admin.firestore().collection('locations').doc(location);
+    const locationSnapshot = await locationRef.get();
+
+    // Check if location document exists
+    if (!locationSnapshot.exists) {
+        return res.status(404).json({ message: 'Location not found.' });
+    }
+
+    // Access document data and get active and queue players
+    const locationData = locationSnapshot.data();
+
+    // Get active players from the location data
+    const activePlayers = locationData.activeFirebaseUIDs;
+
+    // Get queue players from the location data
+    const queuePlayers = locationData.queueFirebaseUIDs;
+
+    // Check for empty active player snapshot
+    if (activePlayers.empty) {
+      return res.status(404).json({ message: 'Invalid location.' });
+    }
+
+    // If there are entries in the queue, no update is required, return 200 status code with updateRequired as false
+    if (!queuePlayers.empty) {
+      return res.status(200).json({
+        updateRequired: false
+      });
+    }
+
+    // Otherwise, return court information where firebaseUID doesn't start with 'Empty'
+    const takenCourts = [];
+    let numberOfCourts = 0;
+
+    // Iterate through active players to find the taken courts, and increment the number of courts
+    activePlayers.forEach((player) => {
+      if (!player.startsWith('Empty')) {
+        takenCourts.push(activePlayers.indexOf(player) + 1);
+        numberOfCourts++;
+      }
+    });
+
+    // Return the taken courts and the number of courts, along with updateRequired as true
+    return res.status(200).json({
+      takenCourts: takenCourts,
+      numberOfCourts: numberOfCourts,
+      updateRequired: true
+    });
+
+  } catch (error) {
+    console.error('Error in getTaken endpoint: ', error);
+    res.status(500).send({ error: 'Failed to get taken courts.' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
# Court Occupancy API

This API provides endpoints to manage and retrieve information about court occupancy. The key functionality of this API includes checking the status of courts, determining whether they are occupied, and providing updates when necessary.

## API Endpoints

```/getTaken``` - Get Info on Taken Courts

#### **Description**
This endpoint retrieves information about the courts that are currently occupied based on a given location. If there are players waiting in the queue, it returns a flag indicating no update is required. Otherwise, it returns the court numbers of the occupied courts, along with the total count and an update flag.

#### **HTTP Method:**
- `POST`

#### **Request Body:**
```json
{
  "location": "Cassie Campbell"
}
```

### API Responses

- **Screenshot 1: Queue Not Empty**
<img width="1038" alt="Screenshot 2024-11-14 at 12 14 12 AM" src="https://github.com/user-attachments/assets/537d8db2-9a4f-4bb0-a5da-e44b5c95faae">

- **Screenshot 2: Queue is Empty**
<img width="1042" alt="Screenshot 2024-11-14 at 12 13 35 AM" src="https://github.com/user-attachments/assets/55c6e790-04f9-477d-8c5c-52556feeaff7">