### PR TITLE
Updated advanceQueue function to fill all empty courts

### DIFF
--- a/backend/utils/addUnknowns.js
+++ b/backend/utils/addUnknowns.js
@@ -1,14 +1,10 @@
+const createTimestamps = require('./createTimestamps');
+
 async function addUnknowns(locationData, occupiedCourts) {
     const { numberOfCourts, activeFirebaseUIDs, activeNicknames, activeWaitingPlayers, activeStartTimes } = locationData;
 
-    const now = new Date();
-    const adjustments = occupiedCourts.map((_, index) => -10 * (index + 1));
-    const timestamps = adjustments.map(seconds => {
-        const adjustedTime = new Date(now);
-        adjustedTime.setSeconds(now.getSeconds() + seconds);
-        return adjustedTime;
-    });
-    shuffleArray(timestamps);
+    // Create an array of adjusted timestamps
+    const timestamps = await createTimestamps(occupiedCourts.length);
     let lastTimestampIdx = 0;
 
     // Process each court based on occupancy status
@@ -38,13 +34,5 @@ async function addUnknowns(locationData, occupiedCourts) {
         }
     }
 }
-
-// Shuffle function
-const shuffleArray = (array) => {
-    for (let i = array.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));  // Random index
-        [array[i], array[j]] = [array[j], array[i]];  // Swap elements
-    }
-};
 
 module.exports = addUnknowns;

--- a/backend/utils/advanceQueue.js
+++ b/backend/utils/advanceQueue.js
@@ -9,7 +9,10 @@ async function advanceQueue(locationData) {
         return;
     }
 
-    // // If there are still empty courts, advance the queue further
+    // Keep track of current unique adjustment and the current time
+    currAdjustment = 0;
+    const now = new Date();
+
     queueAdvanced = false;
     for (let i = 0; i < activeFirebaseUIDs.length; i++) {
         
@@ -20,6 +23,11 @@ async function advanceQueue(locationData) {
 
         // If current court is empty, move first player in the current queue to active
         if (activeFirebaseUIDs[i].startsWith('Empty')) {
+            // Create adjusted timestamp for the new player
+            const adjustedTime = new Date(now);
+            adjustedTime.setSeconds(now.getSeconds() + currAdjustment);
+            currAdjustment -= 10;
+            
             // Get UID and nickname of first player in the current queue
             const firstQueuePlayerUID = queueFirebaseUIDs.shift();
             const firstQueuePlayerNickname = queueNicknames.shift();
@@ -27,7 +35,7 @@ async function advanceQueue(locationData) {
             // Update active data to reflect the new player
             activeFirebaseUIDs[i] = firstQueuePlayerUID; 
             activeNicknames[i] = firstQueuePlayerNickname;
-            activeStartTimes[i] = new Date();
+            activeStartTimes[i] = adjustedTime;
             activeWaitingPlayers[i] = false;  
 
             queueAdvanced = true;

--- a/backend/utils/advanceQueue.js
+++ b/backend/utils/advanceQueue.js
@@ -25,13 +25,15 @@ async function advanceQueue(locationData) {
             const firstQueuePlayerNickname = queueNicknames.shift();
             
             // Update active data to reflect the new player
-            activeFirebaseUIDs[emptyCourtIdx] = firstQueuePlayerUID; 
-            activeNicknames[emptyCourtIdx] = firstQueuePlayerNickname;
-            activeStartTimes[emptyCourtIdx] = new Date();
-            activeWaitingPlayers[emptyCourtIdx] = false;  
+            activeFirebaseUIDs[i] = firstQueuePlayerUID; 
+            activeNicknames[i] = firstQueuePlayerNickname;
+            activeStartTimes[i] = new Date();
+            activeWaitingPlayers[i] = false;  
 
-            await sendWebNotification(firstQueuePlayerUID, `It\'s now your turn at court ${i + 1}!`);
             queueAdvanced = true;
+
+            // Notify the player that it's now their turn
+            // await sendWebNotification(firstQueuePlayerUID, `It\'s now your turn at court ${i + 1}!`);
         }
     }
 

--- a/backend/utils/advanceQueue.js
+++ b/backend/utils/advanceQueue.js
@@ -9,22 +9,38 @@ async function advanceQueue(locationData) {
         return;
     }
 
-    // Get empty court index, and validate
-    const emptyCourtIdx = activeFirebaseUIDs.findIndex((firebaseUID) => firebaseUID.startsWith('Empty'));
-    // if there are no empty courts, emptyCourtIdx will be -1 (don't advance the queue)
-    if (emptyCourtIdx === -1) { 
+    // // If there are still empty courts, advance the queue further
+    queueAdvanced = false;
+    for (let i = 0; i < activeFirebaseUIDs.length; i++) {
+        
+        // If there are no more players in the queue, return early (don't advance the queue further)
+        if (queueFirebaseUIDs.length === 0) {
+            break;
+        }
+
+        // If current court is empty, move first player in the current queue to active
+        if (activeFirebaseUIDs[i].startsWith('Empty')) {
+            // Get UID and nickname of first player in the current queue
+            const firstQueuePlayerUID = queueFirebaseUIDs.shift();
+            const firstQueuePlayerNickname = queueNicknames.shift();
+            
+            // Update active data to reflect the new player
+            activeFirebaseUIDs[emptyCourtIdx] = firstQueuePlayerUID; 
+            activeNicknames[emptyCourtIdx] = firstQueuePlayerNickname;
+            activeStartTimes[emptyCourtIdx] = new Date();
+            activeWaitingPlayers[emptyCourtIdx] = false;  
+
+            await sendWebNotification(firstQueuePlayerUID, `It\'s now your turn at court ${i + 1}!`);
+            queueAdvanced = true;
+        }
+    }
+
+    // If queue was not advanced, return early (no need to call dynamicBuffer and sendWebNotification)
+    if (!queueAdvanced) {
         return;
     }
 
-    // Move first player in the queue to active
-    const firstPlayerUID = queueFirebaseUIDs.shift();
-    const firstPlayerNickname = queueNicknames.shift();
-    activeFirebaseUIDs[emptyCourtIdx] = firstPlayerUID; 
-    activeNicknames[emptyCourtIdx] = firstPlayerNickname;
-    activeStartTimes[emptyCourtIdx] = new Date();
-    activeWaitingPlayers[emptyCourtIdx] = false;    
-
-    // Call dynamicBuffer 
+    // Call dynamicBuffer
     // await dynamicBuffer(locationData);
 
     // If queue is not empty, notify next player that they are now first in line

--- a/backend/utils/advanceQueue.js
+++ b/backend/utils/advanceQueue.js
@@ -1,12 +1,13 @@
-const dynamicBuffer = require('./dynamicBuffer'); // Import dynamicBuffer 
-// const sendWebNotification = require('./sendWebNotification'); // Import sendWebNotification 
+const dynamicBuffer = require('./dynamicBuffer'); // Import dynamicBuffer
+// const sendWebNotification = require('./sendWebNotification'); // Import sendWebNotification
+const createTimestamps = require('./createTimestamps');
 
 async function advanceQueue(locationData) {
     const { activeFirebaseUIDs, activeNicknames, activeStartTimes, activeWaitingPlayers, queueFirebaseUIDs, queueNicknames } = locationData;
 
-    // Keep track of current unique adjustment and the current time
-    currAdjustment = 0;
-    const now = new Date();
+    // Create an array of adjusted timestamps
+    const timestamps = await createTimestamps(activeFirebaseUIDs.length);
+    let lastTimestampIdx = 0;
 
     queueAdvanced = false;
     for (let i = 0; i < activeFirebaseUIDs.length; i++) {
@@ -18,11 +19,6 @@ async function advanceQueue(locationData) {
 
         // If current court is empty, move first player in the current queue to active
         if (activeFirebaseUIDs[i].startsWith('Empty')) {
-            // Create adjusted timestamp for the new player
-            const adjustedTime = new Date(now);
-            adjustedTime.setSeconds(now.getSeconds() + currAdjustment);
-            currAdjustment -= 10;
-            
             // Get UID and nickname of first player in the current queue
             const firstQueuePlayerUID = queueFirebaseUIDs.shift();
             const firstQueuePlayerNickname = queueNicknames.shift();
@@ -30,9 +26,10 @@ async function advanceQueue(locationData) {
             // Update active data to reflect the new player
             activeFirebaseUIDs[i] = firstQueuePlayerUID; 
             activeNicknames[i] = firstQueuePlayerNickname;
-            activeStartTimes[i] = adjustedTime;
+            activeStartTimes[i] = timestamps[lastTimestampIdx];
             activeWaitingPlayers[i] = false;  
 
+            lastTimestampIdx += 1;
             queueAdvanced = true;
 
             // Notify the player that it's now their turn

--- a/backend/utils/advanceQueue.js
+++ b/backend/utils/advanceQueue.js
@@ -4,11 +4,6 @@
 async function advanceQueue(locationData) {
     const { activeFirebaseUIDs, activeNicknames, activeStartTimes, activeWaitingPlayers, queueFirebaseUIDs, queueNicknames } = locationData;
 
-    // If there are no players in the queue, return early (don't advance the queue)
-    if (queueFirebaseUIDs.length === 0) {
-        return;
-    }
-
     // Keep track of current unique adjustment and the current time
     currAdjustment = 0;
     const now = new Date();

--- a/backend/utils/createTimestamps.js
+++ b/backend/utils/createTimestamps.js
@@ -1,0 +1,24 @@
+async function createTimestamps(numOfStamps) {
+    const now = new Date();
+    const adjustedTimestamps = [];
+    
+    for (let i = 0; i < numOfStamps; i++) {
+        const adjustment = -10 * (i + 1)
+        const adjustedTime = new Date(now);
+        adjustedTime.setSeconds(now.getSeconds() + adjustment)
+        adjustedTimestamps.push(adjustedTime); 
+    }
+
+    shuffleArray(adjustedTimestamps);
+    return adjustedTimestamps;
+}
+
+// Shuffle function
+const shuffleArray = (array) => {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));  // Random index
+        [array[i], array[j]] = [array[j], array[i]];  // Swap elements
+    }
+};
+
+module.exports = createTimestamps;


### PR DESCRIPTION
This PR updates the advanceQueue utility function to fill all empty courts. Previously, the function filled one empty court with the first queued player, but that implementation wouldn't be the most helpful when there are more empty courts.

**Note**: The calls to dynamicBuffer and sendWebNotification inside the utility function have been commented out since they haven't been implemented.

Screenshot of the Postman test:
<img width="1011" alt="Screenshot 2024-11-20 at 19 44 48" src="https://github.com/user-attachments/assets/062b7331-f225-43be-8377-77483bd30de3">

Screenshots of Firestore before the endpoint was called:
<img width="1077" alt="Screenshot 2024-11-20 at 19 38 33" src="https://github.com/user-attachments/assets/c2e3f28a-ece3-4ac4-83b3-e00e46319fbc">
<img width="1072" alt="Screenshot 2024-11-20 at 19 38 44" src="https://github.com/user-attachments/assets/833b9cfc-905a-429a-8630-0b2b0a06082f">
<img width="1073" alt="Screenshot 2024-11-20 at 19 38 59" src="https://github.com/user-attachments/assets/4482029f-a647-4929-9bcb-6b809d4da16c">

Screenshots of Firestore after the endpoint was called with the queue and active players updated:
<img width="1075" alt="Screenshot 2024-11-20 at 19 39 56" src="https://github.com/user-attachments/assets/438e5dfd-cf00-441e-b16d-8b987b8a2588">
<img width="1074" alt="Screenshot 2024-11-20 at 19 40 10" src="https://github.com/user-attachments/assets/7506affa-11b7-4c56-88ea-bdc96bfc2f99">
<img width="1071" alt="Screenshot 2024-11-20 at 19 40 21" src="https://github.com/user-attachments/assets/616135a5-56be-4e21-a687-b43806075279">

**Notice:** "Johnny" (UID: RsQSXPzdRoM2EoA0ybDkAYJL8xg2) was first in the queue and moved the 3rd court, and "jknk" (UID: wZvDpMlIgpfRa9400fkNhm61eJg2) was second in the queue and moved to the 4th court.