### PR TITLE
Add Additional Options for Users Whose Time is up

### DIFF
--- a/frontend/src/pages/ActiveView/RectangleWithOptions.css
+++ b/frontend/src/pages/ActiveView/RectangleWithOptions.css
@@ -29,10 +29,6 @@
 }
 
 .action-button {
-  position: absolute;
-  right: 0;
-  top: 100%;
-  margin-top: 5px; /* Position the button right below the rectangle */
   padding: 5px 10px;
   background-color: #007bff;
   color: white;
@@ -46,10 +42,17 @@
   background-color: #0056b3;
 }
 
-.button-container {
+.action-button-container {
   display: flex;
-  gap: 10px; /* Space between buttons */
   position: absolute;
-  top: 100%; /* Position below the rectangle */
-  left: 0;
+  flex-direction: column;
+  top: 100%;
+  right: 0;
+  margin-top: 1px;
+  gap: 10px;
+  z-index: 9999; /* ensure it's always on top */
+  background-color: #F0F0F0;
+  padding: 10px 5px;
+  border: 1px solid black;
+  border-top: none;
 }

--- a/frontend/src/pages/ActiveView/RectangleWithOptions.tsx
+++ b/frontend/src/pages/ActiveView/RectangleWithOptions.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";  // For navigation
-import { leaveQueue, endSession } from "../../utils/api";  // Import utility functions
+import { leaveQueue, endSession, sendWebNotification } from "../../utils/api";  // Import utility functions
 import ConfirmationModal from "./ConfirmationModal";  // Import modal
 import "./RectangleWithOptions.css";
 
@@ -17,8 +17,19 @@ interface RectangleWithOptionsProps {
 const BUTTON_TEXT = {
   OWN_SESSION: "End your session?",
   IN_QUEUE: "Leave the queue?",
-  LEFT_EARLY: "Report Empty"
+  LEFT_EARLY: "Report Empty",
+  NOTIFY_PLAYER: "Send Reminder",
+  OUT_OF_TIME: "Time's Up!",
 };
+
+// Actions constants
+const ACTIONS = {
+  LEAVE_QUEUE: "leaveQueue",
+  END_SESSION: "endSession",
+  END_OTHER_SESSION: "endOtherSession",
+  SEND_WEB_REMINDER: "sendWebReminder",
+  
+}
 
 const RectangleWithOptions: React.FC<RectangleWithOptionsProps> = ({
   nickname,
@@ -31,16 +42,27 @@ const RectangleWithOptions: React.FC<RectangleWithOptionsProps> = ({
   const [showButton, setShowButton] = useState(false);
   const [showModal, setShowModal] = useState(false);  // Track modal visibility
   const [actionToConfirm, setActionToConfirm] = useState("");  // Track the action to confirm
+  const [userOutOftime, setUserOutOfTime] = useState(false);
+
   const buttonRef = useRef(null);
   const rectangleRef = useRef(null);
   const navigate = useNavigate();  // Hook to navigate to other routes
 
   // Determines if the button text should change based on user comparison
-  const determineButtonText = () => {
+  const determineButtonText = (buttonNum: number = 0) => {
     if (userFirebaseUID === firebaseUID) {
       return inQueue ? BUTTON_TEXT.IN_QUEUE : BUTTON_TEXT.OWN_SESSION;
     } else {
-      return BUTTON_TEXT.LEFT_EARLY;
+      switch (buttonNum) {
+        case 1:
+          return BUTTON_TEXT.LEFT_EARLY;
+        case 2:
+          return BUTTON_TEXT.NOTIFY_PLAYER;
+        case 3:
+          return BUTTON_TEXT.OUT_OF_TIME;
+        default:
+          return BUTTON_TEXT.LEFT_EARLY
+      }
     }
   };
 
@@ -66,16 +88,33 @@ const RectangleWithOptions: React.FC<RectangleWithOptionsProps> = ({
   };
 
   // Handle button click event for leaving the queue or ending session
-  const handleButtonClick = () => {
+  const handleButtonClick = (buttonNumber: number = 0) => {
     if (userFirebaseUID === firebaseUID) {
       if (inQueue) {
-        setActionToConfirm("leaveQueue");
+        setActionToConfirm(ACTIONS.LEAVE_QUEUE);
       } else {
-        setActionToConfirm("endSession");
+        setActionToConfirm(ACTIONS.END_SESSION);
       }
       setShowModal(true);
     } else {
-      setActionToConfirm("endOtherSession");
+      switch (buttonNumber) {
+        case 1: {
+          setActionToConfirm(ACTIONS.END_OTHER_SESSION);
+          break;
+        }
+        case 2: {
+          setActionToConfirm(ACTIONS.SEND_WEB_REMINDER);
+          break;
+        }
+        case 3: {
+          setActionToConfirm(ACTIONS.END_SESSION);
+          break;
+        }
+        default: {
+          setActionToConfirm(ACTIONS.END_OTHER_SESSION);
+          break;
+        }
+      }
       setShowModal(true);
     }
   };
@@ -83,15 +122,18 @@ const RectangleWithOptions: React.FC<RectangleWithOptionsProps> = ({
   // Handle modal confirmation (Leave Queue or End Session)
   const handleConfirm = async () => {
     try {
-      if (actionToConfirm === "leaveQueue") {
+      if (actionToConfirm === ACTIONS.LEAVE_QUEUE) {
         await leaveQueue(location, firebaseUID);  // User is leaving the queue
         alert("You have left the queue.");
-      } else if (actionToConfirm === "endSession") {
+      } else if (actionToConfirm === ACTIONS.END_SESSION) {
         await endSession(location, firebaseUID);  // User is ending their own session
         alert("Session ended.");
-      } else if (actionToConfirm === "endOtherSession") {
+      } else if (actionToConfirm === ACTIONS.END_OTHER_SESSION) {
         await endSession(location, firebaseUID);  // Force others to end their session
         alert("Player session ended.");
+      } else if (actionToConfirm === ACTIONS.SEND_WEB_REMINDER) {
+        await sendWebNotification(location, firebaseUID, "Time is up! Please end your session.");
+        alert("Sent reminder to player.")
       }
 
       // Close the modal first
@@ -114,6 +156,15 @@ const RectangleWithOptions: React.FC<RectangleWithOptionsProps> = ({
     setShowModal(false);  // Close the modal without taking any action
   };
 
+  // Update if the user's nickname shows they are out of time
+  useEffect(() => {
+    if (nickname.includes("[") || nickname.includes("]")) {
+      setUserOutOfTime(true);
+    } else {
+      setUserOutOfTime(false);
+    }
+  }, [nickname]);
+
   // Set up event listener to handle outside clicks
   useEffect(() => {
     document.addEventListener("click", handleClickOutside);
@@ -128,7 +179,7 @@ const RectangleWithOptions: React.FC<RectangleWithOptionsProps> = ({
 
       {/* Display dots for toggling the button */}
       {!shouldIgnoreButton() && (
-        <>
+        <div className="right-container">
           <div
             className="dots-container"
             onClick={() => setShowButton((prev) => !prev)}
@@ -138,17 +189,38 @@ const RectangleWithOptions: React.FC<RectangleWithOptionsProps> = ({
             <div className="dot"></div>
           </div>
 
-          {/* Conditionally render the button */}
+
+
           {showButton && (
-            <button
-              ref={buttonRef}
-              className="action-button"
-              onClick={handleButtonClick}
-            >
-              {determineButtonText()}
-            </button>
+            <>
+            {/* Conditionally render the button(s) */}
+            <div className="action-button-container">
+            {userOutOftime && (
+              [1, 2, 3].map((buttonNumber: number) => {
+                return (
+                  <button
+                    ref={buttonRef}
+                    className="action-button"
+                    onClick={() => handleButtonClick(buttonNumber)}
+                  >
+                    {determineButtonText(buttonNumber)}
+                  </button>
+                )})
+            )}
+
+            {!userOutOftime && (
+                <button
+                  ref={buttonRef}
+                  className="action-button"
+                  onClick={() => handleButtonClick()}
+                >
+                  {determineButtonText()}
+                </button>
+            )}
+            </div>
+            </>
           )}
-        </>
+        </div>
       )}
 
       {/* Confirmation Modal */}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -115,6 +115,35 @@ export const leaveQueue = async (locationName, firebaseUID, retries = 3, delay =
 };
 
 
+// Send a reminder to an active player with the /sendWebNotification  endpoint
+export const sendWebNotification = async (locationName, firebaseUID, message, retries = 3, delay = 500) => {
+  try {
+    const response = await fetch(`${BACKEND_API}/api/sendWebNotification`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        location: locationName,
+        firebaseUID: firebaseUID,
+        message: message,
+      }),
+    });
+    if (!response.ok) throw new Error('Failed to send web notification.');
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    if (retries > 0) {
+      console.log(`Retrying sendWebNotification (${retries} retries left)...`);
+      await new Promise(res => setTimeout(res, delay));  // Exponential backoff
+      return await leaveQueue(locationName, firebaseUID, retries - 1, delay * 2);  // Up to 3 retries
+    }
+    console.error("Error leaving queue:", error);
+    return null;
+  }
+};
+
+
 // ** UTILITY FUNCTION TO CREATE FIRESTORE LISTENER **
 
 // Subscribe to Firestore snapshot for a specific location document

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -136,9 +136,9 @@ export const sendWebNotification = async (locationName, firebaseUID, message, re
     if (retries > 0) {
       console.log(`Retrying sendWebNotification (${retries} retries left)...`);
       await new Promise(res => setTimeout(res, delay));  // Exponential backoff
-      return await leaveQueue(locationName, firebaseUID, retries - 1, delay * 2);  // Up to 3 retries
+      return await sendWebNotification(locationName, firebaseUID, message, retries - 1, delay * 2);  // Up to 3 retries
     }
-    console.error("Error leaving queue:", error);
+    console.error("Error sending web notification:", error);
     return null;
   }
 };


### PR DESCRIPTION
## Overview
This PR adds two additional options for users whose time is up (denoted by having [] wrapping their nickname), adding the option to send a notification or kick them out. Both new buttons follow the AC of issue #76 .
This also does a bit of refactoring, adding some constant enums and changing the design/structure of the `RectangleWithOptions` component to allow for n-many buttons in the dotted menu.

## Screenshots of behaviour
New buttons for player whose time is up:
![image](https://github.com/user-attachments/assets/f51420fb-29af-44a0-96c1-7b481e0176a6)

Screenshots showing existing behaviour is unaffected
![image](https://github.com/user-attachments/assets/3f0952a2-b52e-460d-9e43-d55705dff2d5)
![image](https://github.com/user-attachments/assets/e1c33a37-babf-49a6-875d-a51f0ef87eb6)

Correct behaviour when `Send Reminder` is pressed (note the API does not exist yet)
![image](https://github.com/user-attachments/assets/5deba85d-8470-4938-b313-9bcfc7e7131b)
Correct behaviour when `Time's Up!` is pressed
![image](https://github.com/user-attachments/assets/31da4343-ff8f-4cb2-8541-057d697b14f9)


## footnote
I added a bit of styling for the menu buttons to make them more visible and accessible (since before the contrast was not as visible, and for those with visual impairments it may have been tougher to see). I'm happy to change the styling if needed!