### PR TITLE
Implement centralized storage via React Context 

### DIFF
--- a/frontend/context/LocalStorageContext.tsx
+++ b/frontend/context/LocalStorageContext.tsx
@@ -1,0 +1,103 @@
+import React, { createContext, useState, useEffect } from 'react';
+
+// INFO: All possible props in this context
+const UserInfoEnum = {
+    selectedLocation: "selectedLocation",
+    firebaseUID: "firebaseUID",
+    nickname: "nickname",
+    addedToGame: "addedToGame",
+    inQueue: "inQueue",
+    playerData: "playerData",
+    playerDataLastUpdateTime: "playerDataLastUpdateTime",
+};
+
+// Context for why this type is set to any: https://stackoverflow.com/a/74967045
+export const LocalStorageContext = createContext<any>({});
+
+export function LocalStorageProvider({ children }) {
+  const [selectedLocation, setSelectedLocation] = useState('');
+  const [firebaseUID, setFirebaseUID] = useState('');
+  const [nickname, setNickname] = useState('');
+  const [addedToGame, setAddedToGame] = useState(false);
+  const [inQueue, setInQueue] = useState(false);
+  const [playerData, setPlayerData] = useState({});
+  const [playerDataLastUpdateTime, setPlayerDataLastUpdateTime] = useState('');
+
+  // Initialize state from localStorage
+  useEffect(() => {
+    const storedSelectedLocation = localStorage.getItem(UserInfoEnum.selectedLocation);
+    const storedFirebaseUID = localStorage.getItem(UserInfoEnum.firebaseUID);
+    const storedNickname = localStorage.getItem(UserInfoEnum.nickname);
+    const storedAddedToGame = localStorage.getItem(UserInfoEnum.addedToGame) === 'true';
+    const storedInQueue = localStorage.getItem(UserInfoEnum.inQueue) === 'true';
+    const storedPlayerData = localStorage.getItem(UserInfoEnum.playerData);
+    const storedPlayerDataLastUpdateTime = localStorage.getItem(UserInfoEnum.playerDataLastUpdateTime);
+
+    if (storedSelectedLocation) setSelectedLocation(storedSelectedLocation);
+    if (storedFirebaseUID) setFirebaseUID(storedFirebaseUID);
+    if (storedNickname) setNickname(storedNickname);
+    if (storedAddedToGame) setAddedToGame(storedAddedToGame);
+    if (storedInQueue) setInQueue(storedInQueue);
+    if (storedPlayerData) setPlayerData(storedPlayerData);
+    if (storedPlayerDataLastUpdateTime) setPlayerDataLastUpdateTime(storedPlayerDataLastUpdateTime);
+  }, []);
+
+  // Helper functions to update both context and localStorage
+  const updateSelectedLocation = (value) => {
+    setSelectedLocation(value);
+    localStorage.setItem(UserInfoEnum.selectedLocation, value);
+  };
+
+  const updateFirebaseUID = (value) => {
+    setFirebaseUID(value);
+    localStorage.setItem(UserInfoEnum.firebaseUID, value);
+  };
+  
+  const updateNickname = (value) => {
+    setNickname(value);
+    localStorage.setItem(UserInfoEnum.nickname, value);
+  };
+
+  const updateAddedToGame = (value) => {
+    setAddedToGame(value);
+    localStorage.setItem(UserInfoEnum.addedToGame, value);
+  };
+
+  const updateInQueue = (value) => {
+    setInQueue(value);
+    localStorage.setItem(UserInfoEnum.inQueue, value.toString());
+  };
+  
+  const updatePlayerData = (value) => {
+    setPlayerData(value);
+    localStorage.setItem(UserInfoEnum.playerData, value);
+  };
+
+  const updatePlayerDataLastUpdateTime = (value) => {
+    setPlayerDataLastUpdateTime(value);
+    localStorage.setItem(UserInfoEnum.playerDataLastUpdateTime, value);
+  };
+
+  return (
+    <LocalStorageContext.Provider
+      value={{
+        selectedLocation,
+        setSelectedLocation: updateSelectedLocation,
+        firebaseUID,
+        setFirebaseUID: updateFirebaseUID,
+        nickname,
+        setNickname: updateNickname,
+        addedToGame,
+        setAddedToGame: updateAddedToGame,
+        inQueue,
+        setInQueue: updateInQueue,
+        playerData,
+        setPlayerData: updatePlayerData,
+        playerDataLastUpdateTime,
+        setPlayerDataLastUpdateTime: updatePlayerDataLastUpdateTime,
+      }}
+    >
+      {children}
+    </LocalStorageContext.Provider>
+  );
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,10 +6,13 @@ import UserInfo from './pages/UserInfo/UserInfoForm';
 import SignIn from './pages/SignIn/SignIn';
 import ActiveView from './pages/ActiveView/ActiveView';
 
+// Import contexts
+import { LocalStorageProvider } from './context/LocalStorageContext';
+
 function App() {
 
   return (
-    <> 
+    <LocalStorageProvider> 
       {/* Navigation Links */}
       <nav>
         <Link to="/">Home</Link>
@@ -23,7 +26,7 @@ function App() {
         <Route path="/sign-in" element={<SignIn />} />
         <Route path="/active-view" element={<ActiveView />} />
       </Routes>
-    </>
+    </LocalStorageProvider>
   );
 }
 

--- a/frontend/src/context/LocalStorageContext.tsx
+++ b/frontend/src/context/LocalStorageContext.tsx
@@ -2,26 +2,29 @@ import React, { createContext, useState, useEffect } from 'react';
 
 // INFO: All possible props in this context
 const UserInfoEnum = {
-    selectedLocation: "selectedLocation",
-    firebaseUID: "firebaseUID",
-    nickname: "nickname",
-    addedToGame: "addedToGame",
-    inQueue: "inQueue",
-    playerData: "playerData",
-    playerDataLastUpdateTime: "playerDataLastUpdateTime",
+  selectedLocation: "selectedLocation",
+  firebaseUID: "firebaseUID",
+  nickname: "nickname",
+  addedToGame: "addedToGame",
+  inQueue: "inQueue",
+  playerData: "playerData",
+  playerDataLastUpdateTime: "playerDataLastUpdateTime",
 };
 
 // Context for why this type is set to any: https://stackoverflow.com/a/74967045
-export const LocalStorageContext = createContext<any>({});
+export const LocalStorageContext = createContext<any>({
+  
+});
 
-export function LocalStorageProvider({ children }) {
-  const [selectedLocation, setSelectedLocation] = useState('');
-  const [firebaseUID, setFirebaseUID] = useState('');
-  const [nickname, setNickname] = useState('');
-  const [addedToGame, setAddedToGame] = useState(false);
-  const [inQueue, setInQueue] = useState(false);
-  const [playerData, setPlayerData] = useState({});
-  const [playerDataLastUpdateTime, setPlayerDataLastUpdateTime] = useState('');
+export function LocalStorageProvider( { children } ) {
+  //  Pull default context from local storage to persist on page reload
+  const [selectedLocation, setSelectedLocation] = useState(localStorage.getItem(UserInfoEnum.selectedLocation) || '');
+  const [firebaseUID, setFirebaseUID] = useState(localStorage.getItem(UserInfoEnum.firebaseUID) || '');
+  const [nickname, setNickname] = useState(localStorage.getItem(UserInfoEnum.nickname) || '');
+  const [addedToGame, setAddedToGame] = useState(localStorage.getItem(UserInfoEnum.addedToGame) === 'true' ? true : false);
+  const [inQueue, setInQueue] = useState(localStorage.getItem(UserInfoEnum.inQueue) === 'true' ? true : false);
+  const [playerData, setPlayerData] = useState(localStorage.getItem(UserInfoEnum.playerData) ? JSON.parse(localStorage.getItem(UserInfoEnum.playerData)!) : '');
+  const [playerDataLastUpdateTime, setPlayerDataLastUpdateTime] = useState(localStorage.getItem(UserInfoEnum.playerDataLastUpdateTime) || '');
 
   // Initialize state from localStorage
   useEffect(() => {
@@ -43,40 +46,51 @@ export function LocalStorageProvider({ children }) {
   }, []);
 
   // Helper functions to update both context and localStorage
-  const updateSelectedLocation = (value) => {
+  const updateSelectedLocation = (value: string) => {
     setSelectedLocation(value);
     localStorage.setItem(UserInfoEnum.selectedLocation, value);
   };
 
-  const updateFirebaseUID = (value) => {
+  const updateFirebaseUID = (value: string) => {
     setFirebaseUID(value);
     localStorage.setItem(UserInfoEnum.firebaseUID, value);
   };
   
-  const updateNickname = (value) => {
+  const updateNickname = (value: string) => {
     setNickname(value);
     localStorage.setItem(UserInfoEnum.nickname, value);
   };
 
-  const updateAddedToGame = (value) => {
+  const updateAddedToGame = (value: boolean) => {
     setAddedToGame(value);
-    localStorage.setItem(UserInfoEnum.addedToGame, value);
+    localStorage.setItem(UserInfoEnum.addedToGame, value.toString());
   };
 
-  const updateInQueue = (value) => {
+  const updateInQueue = (value: boolean) => {
     setInQueue(value);
     localStorage.setItem(UserInfoEnum.inQueue, value.toString());
   };
   
-  const updatePlayerData = (value) => {
+  const updatePlayerData = (value: string) => {
     setPlayerData(value);
     localStorage.setItem(UserInfoEnum.playerData, value);
   };
 
-  const updatePlayerDataLastUpdateTime = (value) => {
+  const updatePlayerDataLastUpdateTime = (value: string) => {
     setPlayerDataLastUpdateTime(value);
     localStorage.setItem(UserInfoEnum.playerDataLastUpdateTime, value);
   };
+
+  const clear = () => {
+    setSelectedLocation('');
+    setFirebaseUID('');
+    setNickname('');
+    setAddedToGame(false);
+    setInQueue(false);
+    setPlayerData({});
+    setPlayerDataLastUpdateTime('');
+    localStorage.clear();
+  }
 
   return (
     <LocalStorageContext.Provider
@@ -95,6 +109,7 @@ export function LocalStorageProvider({ children }) {
         setPlayerData: updatePlayerData,
         playerDataLastUpdateTime,
         setPlayerDataLastUpdateTime: updatePlayerDataLastUpdateTime,
+        clear: clear,
       }}
     >
       {children}

--- a/frontend/src/pages/ActiveView/ActiveView.tsx
+++ b/frontend/src/pages/ActiveView/ActiveView.tsx
@@ -1,13 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import './ActiveView.css';
 import CurrentState from './CurrentState';
 import { joinGame } from '../../utils/api';
+import { LocalStorageContext } from '../../context/LocalStorageContext';
 
 const ActiveView: React.FC = () => {
-  const location = localStorage.getItem('selectedLocation');
-  const firebaseUID = localStorage.getItem('firebaseUID');
-  const nickname = localStorage.getItem('nickname');
+  const context = useContext(LocalStorageContext);
+
+  const location = context.selectedLocation;
+  const firebaseUID = context.firebaseUID;
+  const nickname = context.nickname;
 
   const [loading, setLoading] = useState<boolean>(true);  // Initially set loading to true
 
@@ -25,13 +28,13 @@ const ActiveView: React.FC = () => {
   }, []);
 
   const initializeGame = async () => {
-    const addedToGame = localStorage.getItem('addedToGame') === 'true';
+    const addedToGame = context.addedToGame;
     if (!addedToGame) {
       setLoading(true);
       try {
         const { status } = await joinGame(location, nickname, firebaseUID); // Call to backend
-        localStorage.setItem('addedToGame', 'true');
-        localStorage.setItem('inQueue', status === 'queue' ? 'true' : 'false');
+        context.setAddedToGame(true);
+        context.setInQueue(status === 'queue' ? true : false);
       } catch (error) {
         console.error('Error joining queue:', error);
         alert('Failed to join the queue. Please try again.');

--- a/frontend/src/pages/ActiveView/PlayerList.tsx
+++ b/frontend/src/pages/ActiveView/PlayerList.tsx
@@ -1,15 +1,13 @@
-import React from "react";
+import React, { useContext } from "react";
 import RectangleWithOptions from "./RectangleWithOptions";
 import "./PlayerList.css";
+import { LocalStorageContext } from "../../context/LocalStorageContext";
 
 interface PlayerListProps {
   activePlayers: string[];
   queuePlayers: string[];
   activeFirebaseUIDs: string[];
   queueFirebaseUIDs: string[];
-  userFirebaseUID: string;
-  userInQueue: boolean;
-  location: string;
 }
 
 const PlayerList: React.FC<PlayerListProps> = ({
@@ -17,9 +15,6 @@ const PlayerList: React.FC<PlayerListProps> = ({
   queuePlayers,
   activeFirebaseUIDs,
   queueFirebaseUIDs,
-  userFirebaseUID,
-  userInQueue,
-  location,
 }) => {
   // Function to clean up nicknames
   const formatNickname = (nickname: string) => {
@@ -39,10 +34,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
               key={index}
               nickname={formatNickname(nickname)}
               firebaseUID={activeFirebaseUIDs[index]}
-              userFirebaseUID={userFirebaseUID}
-              userInQueue={userInQueue}
               inQueue={false}
-              location={location}
             />
           ))}
         </div>
@@ -56,10 +48,7 @@ const PlayerList: React.FC<PlayerListProps> = ({
                 key={index}
                 nickname={formatNickname(nickname)}
                 firebaseUID={queueFirebaseUIDs[index]}
-                userFirebaseUID={userFirebaseUID}
-                userInQueue={userInQueue}
                 inQueue={true}
-                location={location}
               />
             ))
           ) : (

--- a/frontend/src/pages/ActiveView/RectangleWithOptions.tsx
+++ b/frontend/src/pages/ActiveView/RectangleWithOptions.tsx
@@ -1,16 +1,14 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useContext } from "react";
 import { useNavigate } from "react-router-dom";  // For navigation
 import { leaveQueue, endSession, sendWebNotification } from "../../utils/api";  // Import utility functions
 import ConfirmationModal from "./ConfirmationModal";  // Import modal
 import "./RectangleWithOptions.css";
+import { LocalStorageContext } from "../../context/LocalStorageContext";
 
 interface RectangleWithOptionsProps {
   nickname: string;
   firebaseUID: string;
-  userFirebaseUID: string;
-  userInQueue: boolean;
   inQueue: boolean;
-  location: string;
 }
 
 // Button text constants
@@ -28,17 +26,19 @@ const ACTIONS = {
   END_SESSION: "endSession",
   END_OTHER_SESSION: "endOtherSession",
   SEND_WEB_REMINDER: "sendWebReminder",
-  
 }
 
 const RectangleWithOptions: React.FC<RectangleWithOptionsProps> = ({
   nickname,
   firebaseUID,
-  userFirebaseUID,
-  userInQueue,
   inQueue,
-  location,
 }) => {
+  const context = useContext(LocalStorageContext);
+
+  const userFirebaseUID = context.firebaseUID;
+  const userInQueue = context.inQueue;
+  const location = context.selectedLocation;
+
   const [showButton, setShowButton] = useState(false);
   const [showModal, setShowModal] = useState(false);  // Track modal visibility
   const [actionToConfirm, setActionToConfirm] = useState("");  // Track the action to confirm
@@ -142,7 +142,7 @@ const RectangleWithOptions: React.FC<RectangleWithOptionsProps> = ({
       // Navigate only if the action was related to the user's own session or leaving the queue
       if (actionToConfirm === "leaveQueue" || actionToConfirm === "endSession") {
         setTimeout(() => {
-          localStorage.clear();  // Clear local storage
+          context.clear();  // Clear local storage
           navigate("/");  // After closing the modal, navigate to the home page
         }, 300); // Optional: small delay to ensure smooth transition
       }

--- a/frontend/src/pages/LocationSelection/LocationSelection.tsx
+++ b/frontend/src/pages/LocationSelection/LocationSelection.tsx
@@ -1,8 +1,11 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import './LocationSelection.css';
+import { LocalStorageContext } from '../../context/LocalStorageContext';
 
 const LocationSelection: React.FC = () => {
+  const context = useContext(LocalStorageContext);
+
   // Sample locations list
   const locations = ["Cassie Campbell"];
 
@@ -16,7 +19,7 @@ const LocationSelection: React.FC = () => {
   // Handle location change
   const handleLocationChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectedLocation(event.target.value);
-    localStorage.setItem('selectedLocation', event.target.value);
+    context.setSelectedLocation(event.target.value);
   };
 
   // Handle the navigation button click

--- a/frontend/src/pages/SignIn/SignIn.tsx
+++ b/frontend/src/pages/SignIn/SignIn.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import { auth } from "../../firebase";
 import {
     signInWithPopup,
@@ -12,7 +12,11 @@ import "./SignIn.css";
 // Import Google icon
 import googleIcon from "../../assets/google-icon.svg";
 
+import { LocalStorageContext } from "../../context/LocalStorageContext";
+
 const Login: React.FC = () => {
+    const context = useContext(LocalStorageContext);
+
     const provider = new GoogleAuthProvider(); // Google authentication provider
 
     // State management for inputs and toggles
@@ -26,13 +30,13 @@ const Login: React.FC = () => {
 
     // Handle Google sign-in
     const handleGoogleSignIn = () => {
-        localStorage.setItem("addedToGame", "false"); // Reset added to game status
+        context.setAddedToGame(false); // Reset added to game status
         signInWithPopup(auth, provider)
             .then((result) => {
                 const user = result.user
                 console.log("user", user)
 
-                localStorage.setItem("firebaseUID", user.uid); // Store user UID in local storage
+                context.setFirebaseUID(user.uid); // Store user UID in local storage
                 setTimeout(() => {}, 1000); // Delay to ensure UID is stored before redirect
                 navigate("/active-view"); // Navigate to active view on success
             })
@@ -110,14 +114,14 @@ const Login: React.FC = () => {
                 }
                 setErrorMessage(errorMsg); // Update error message
             });
-        localStorage.setItem("addedToGame", "false");
+        context.setAddedToGame(false);
         signInWithPopup(auth, provider)
         .then((result) => {
             const user = result.user;
             console.log("User: ", user);
             // Set authenticated state to true
-            setIsAuthenticated(true);
-            localStorage.setItem("firebaseUID", user.uid);
+            // setIsAuthenticated(true);
+            context.setFirebaseUID(user.uid);
             setTimeout(() => {}, 1000);
             navigate('/active-view'); // Navigate to the next page
         }).catch((error) => {

--- a/frontend/src/pages/UserInfo/UserInfoForm.tsx
+++ b/frontend/src/pages/UserInfo/UserInfoForm.tsx
@@ -1,9 +1,12 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import './UserInfoForm.css';
 import ConfirmationModal from './ConfirmationModal';
+import { LocalStorageContext } from '../../context/LocalStorageContext';
 
 const UserInfo: React.FC = () => {
+  const context = useContext(LocalStorageContext);
+
   // State for nickname input field
   const [nickname, setNickname] = useState<string>('');
   const [groupSize, setGroupSize] = useState<string>('');
@@ -105,7 +108,7 @@ const UserInfo: React.FC = () => {
   const handleConfirm = () => {
     setShowModal(false); // Close the modal
     const nicknameWithGroup = `${nickname} +${Number(groupSize) - 1}`;
-    localStorage.setItem('nickname', nicknameWithGroup);
+    context.setNickname(nicknameWithGroup);
     // we are explicitly choosing NOT to save groupSize to local storage
     navigate('/sign-in'); // Navigate to the next page
   };


### PR DESCRIPTION
This PR replaces current repeated calls to `localStorage` with a new centralized `LocalStorageContext` API, which can be accessed with the `useContext` hook. This PR also removes prop drilling, which can be simplified with this context API.

Linked issue: #71 

## General explanation of flow
Most of the work done occurs in `frontend/src/context/LocalStorageContext.tsx`
- Whenever the page loads, the context will read from localStorage, or set default values (so that on a page refresh, the context persists)
- It then exposes these values, and also adds wrappers around the set...() functions so that they update both the context as well as local storage whenever you use it
- All occurrences of localStorage are replaced with a call to context
- Whenever there was prop drilling, it has been replaced with using this context object as needed (notably in PlayerList and RectangleWithOptions)

## Walkthrough of the flow;
initial state:
![image](https://github.com/user-attachments/assets/9c6e543f-28c9-4c58-8622-02c24f15d3da)
immediately after setting location:
![image](https://github.com/user-attachments/assets/a22e6c6f-478a-498f-a4c5-3f3c5181bb0f)
after setting your nickname/group, and refreshing: information persists in the context and local storage
![image](https://github.com/user-attachments/assets/708d52da-b539-4701-b8be-f21b3662b0c1)
loaded screen after successfully signing in via google:
![image](https://github.com/user-attachments/assets/c2f21292-c132-4db0-b444-15ca507bb605)
log of the context object to show it's mirroring local storage as required:
![image](https://github.com/user-attachments/assets/c848d407-967a-49a3-a0fa-d99988ed8963)
all local storage being cleared on logout:
![image](https://github.com/user-attachments/assets/f7b0e0b3-eb25-4c73-bbfc-0a86ed8c019c)
context also being cleared on logout:
![image](https://github.com/user-attachments/assets/28512d1d-0129-4356-a634-94d0dae388fb)
