### PR TITLE
Fix sign-in and sign-up bug

### DIFF
--- a/frontend/src/pages/SignIn/SignIn.tsx
+++ b/frontend/src/pages/SignIn/SignIn.tsx
@@ -169,7 +169,7 @@ const handleEmailAuth = (e: React.FormEvent) => {
                     {isSigningUp ? "Sign In" : "Sign Up"}
                 </span>
             </p>
-
+            <br></br>
             {/* Google sign-in button */}
             <div className="google-signin-container">
                 <button className="button google-signin-button" onClick={handleGoogleSignIn}>

--- a/frontend/src/pages/SignIn/SignIn.tsx
+++ b/frontend/src/pages/SignIn/SignIn.tsx
@@ -51,65 +51,70 @@ const Login: React.FC = () => {
     };
 
     // Handle email-based authentication
-    const handleEmailAuth = (e: React.FormEvent) => {
-        e.preventDefault(); 
-        setEmailError(""); 
-        setPasswordError(""); 
-        setErrorMessage("");
+const handleEmailAuth = (e: React.FormEvent) => {
+    e.preventDefault();
+    setEmailError(""); 
+    setPasswordError(""); 
+    setErrorMessage("");
 
-        let isValid = true;
+    let isValid = true;
 
-        if (!isValidEmail(email)) {
-            setEmailError("Invalid email format. Please enter a valid email address.");
-            isValid = false;
-        }
+    if (!isValidEmail(email)) {
+        setEmailError("Invalid email format. Please enter a valid email address.");
+        isValid = false;
+    }
 
-        if (!isValidPassword(password)) {
-            setPasswordError("Password must be at least 8 characters long.");
-            isValid = false;
-        }
+    if (!isValidPassword(password)) {
+        setPasswordError("Password must be at least 8 characters long.");
+        isValid = false;
+    }
 
-        if (!isValid) return;
+    if (!isValid) return;
 
-        const authFunction = isSigningUp
-            ? createUserWithEmailAndPassword
-            : signInWithEmailAndPassword;
+    const authFunction = isSigningUp
+        ? createUserWithEmailAndPassword
+        : signInWithEmailAndPassword;
 
-        authFunction(auth, email, password)
-            .then(() => {
-                navigate("/active-view"); // Navigate to active view on success if sign-in or sign-up is successful
-            })
-            // Handle Firebase errors if authentication fails
-            .catch((error) => {
-                let errorMsg = "An unexpected error occurred. Please try again.";
-                switch (error.code) {
-                    case "auth/email-already-in-use":
-                        errorMsg = "This email is already in use. Please try signing in instead.";
-                        break;
-                    case "auth/invalid-email":
-                        errorMsg = "Invalid email address. Please try again.";
-                        break;
-                    case "auth/weak-password":
-                        errorMsg = "Weak password. Choose a stronger one.";
-                        break;
-                    case "auth/wrong-password":
-                        errorMsg = "Incorrect password. Please try again.";
-                        break;
-                    case "auth/user-not-found":
-                        errorMsg = "No account found. Please sign up.";
-                        break;
-                    case "auth/network-request-failed":
-                        errorMsg = "Network error. Check your connection.";
-                        break;
-                    case "auth/invalid-credential":
-                        errorMsg = "Invalid credentials. Try again.";
-                        break;
-                    default:
-                        errorMsg = error.message; // Default error message
-                        break;
-                }
-                setErrorMessage(errorMsg); // Update error message
-            });
+    authFunction(auth, email, password)
+        .then((userCredential) => {
+            localStorage.setItem("addedToGame", "false");
+            const user = userCredential.user; // This is the user object
+            console.log("User UID:", user.uid); // This is the user's UID
+            localStorage.setItem("firebaseUID", user.uid); // Store the UID in localStorage if needed
+            console.log("User:", user);
+            navigate("/active-view"); // Navigate to the next page
+        })
+        // Handle Firebase errors if authentication fails
+        .catch((error) => {
+            let errorMsg = "An unexpected error occurred. Please try again.";
+            switch (error.code) {
+                case "auth/email-already-in-use":
+                    errorMsg = "This email is already in use. Please try signing in instead.";
+                    break;
+                case "auth/invalid-email":
+                    errorMsg = "Invalid email address. Please try again.";
+                    break;
+                case "auth/weak-password":
+                    errorMsg = "Weak password. Choose a stronger one.";
+                    break;
+                case "auth/wrong-password":
+                    errorMsg = "Incorrect password. Please try again.";
+                    break;
+                case "auth/user-not-found":
+                    errorMsg = "No account found. Please sign up.";
+                    break;
+                case "auth/network-request-failed":
+                    errorMsg = "Network error. Check your connection.";
+                    break;
+                case "auth/invalid-credential":
+                    errorMsg = "Invalid credentials. Try again.";
+                    break;
+                default:
+                    errorMsg = error.message; // Default error message
+                    break;
+            }
+            setErrorMessage(errorMsg); // Update error message
+        });
     };
 
     return (

--- a/frontend/src/pages/SignIn/SignIn.tsx
+++ b/frontend/src/pages/SignIn/SignIn.tsx
@@ -8,68 +8,68 @@ import {
 } from "firebase/auth";
 import { useNavigate } from "react-router-dom";
 import "./SignIn.css";
-
-// Import Google icon
 import googleIcon from "../../assets/google-icon.svg";
 
 const Login: React.FC = () => {
-    const provider = new GoogleAuthProvider(); // Google authentication provider
+    // Initialize Google authentication provider
+    const provider = new GoogleAuthProvider();
 
-    // State management for inputs and toggles
-    const [email, setEmail] = useState(""); // Email input
-    const [password, setPassword] = useState(""); // Password input
-    const [isSigningUp, setIsSigningUp] = useState(false); // Toggle for sign-up or sign-in
-    const [errorMessage, setErrorMessage] = useState(""); // Error message display
-    const [inputError, setInputError] = useState(""); // Input-specific error messages
+    // State variables for form inputs
+    const [email, setEmail] = useState(""); // set email
+    const [password, setPassword] = useState(""); // set password
+    const [isSigningUp, setIsSigningUp] = useState(false); // set isSigningUp to false
+    const [errorMessage, setErrorMessage] = useState("");  // Error message state
+    const [emailError, setEmailError] = useState(""); // Email-specific error state
+    const [passwordError, setPasswordError] = useState(""); // Password-specific error state
+    const navigate = useNavigate(); // Navigate to the next page
 
-    const navigate = useNavigate(); // Navigation hook for redirecting
-
-    // Handle Google sign-in
+    // Handle email-based authentication
     const handleGoogleSignIn = () => {
-        localStorage.setItem("addedToGame", "false"); // Reset added to game status
+        localStorage.setItem("addedToGame", "false"); 
         signInWithPopup(auth, provider)
             .then((result) => {
-                const user = result.user
-                console.log("user", user)
-
-                localStorage.setItem("firebaseUID", user.uid); // Store user UID in local storage
-                setTimeout(() => {}, 1000); // Delay to ensure UID is stored before redirect
-                navigate("/active-view"); // Navigate to active view on success
+                const user = result.user;
+                console.log("user", user);
+                localStorage.setItem("firebaseUID", user.uid);
+                setTimeout(() => {}, 1000);
+                navigate("/active-view");
             })
             .catch(() => {
-                setErrorMessage("Google sign-in failed. Please try again."); // Set error message
+                setErrorMessage("Google sign-in failed. Please try again.");
             });
     };
 
-    // Validate email format
+    // Register a new user or sign in an existing user with email and password
     const isValidEmail = (email: string) => {
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
         return emailRegex.test(email);
     };
 
-    // Validate password length
+    // Validate password length (minimum 8 characters)
     const isValidPassword = (password: string) => {
         return password.length >= 8;
     };
 
     // Handle email-based authentication
     const handleEmailAuth = (e: React.FormEvent) => {
-        e.preventDefault(); // Prevent page reload
-
-        // Reset input errors
-        setInputError("");
+        e.preventDefault(); 
+        setEmailError(""); 
+        setPasswordError(""); 
         setErrorMessage("");
 
-        // Input validation
+        let isValid = true;
+
         if (!isValidEmail(email)) {
-            setInputError("Invalid email format. Please enter a valid email address.");
-            return;
+            setEmailError("Invalid email format. Please enter a valid email address.");
+            isValid = false;
         }
 
         if (!isValidPassword(password)) {
-            setInputError("Password must be at least 8 characters long.");
-            return;
+            setPasswordError("Password must be at least 8 characters long.");
+            isValid = false;
         }
+
+        if (!isValid) return;
 
         const authFunction = isSigningUp
             ? createUserWithEmailAndPassword
@@ -77,10 +77,10 @@ const Login: React.FC = () => {
 
         authFunction(auth, email, password)
             .then(() => {
-                navigate("/active-view"); // Navigate to active view on success
+                navigate("/active-view"); // Navigate to active view on success if sign-in or sign-up is successful
             })
+            // Handle Firebase errors if authentication fails
             .catch((error) => {
-                // Map Firebase error codes to user-friendly messages
                 let errorMsg = "An unexpected error occurred. Please try again.";
                 switch (error.code) {
                     case "auth/email-already-in-use":
@@ -110,19 +110,6 @@ const Login: React.FC = () => {
                 }
                 setErrorMessage(errorMsg); // Update error message
             });
-        localStorage.setItem("addedToGame", "false");
-        signInWithPopup(auth, provider)
-        .then((result) => {
-            const user = result.user;
-            console.log("User: ", user);
-            // Set authenticated state to true
-            setIsAuthenticated(true);
-            localStorage.setItem("firebaseUID", user.uid);
-            setTimeout(() => {}, 1000);
-            navigate('/active-view'); // Navigate to the next page
-        }).catch((error) => {
-            console.log("Error: ", error);
-        });
     };
 
     return (
@@ -136,29 +123,30 @@ const Login: React.FC = () => {
                     <input
                         type="email"
                         id="email"
-                        className={`form-input ${inputError ? "input-error" : ""}`}
+                        className={`form-input ${emailError ? "input-error" : ""}`}
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
                         required
                     />
+                    {emailError && <p className="error-message">{emailError}</p>}
                 </div>
                 <div className="form-group">
                     <label htmlFor="password">Password:</label>
                     <input
                         type="password"
                         id="password"
-                        className={`form-input ${inputError ? "input-error" : ""}`}
+                        className={`form-input ${passwordError ? "input-error" : ""}`}
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
                         required
                     />
+                    {passwordError && <p className="error-message">{passwordError}</p>}
                 </div>
                 <button type="submit" className="form-button email-button">
                     {isSigningUp ? "Sign Up with Email" : "Sign In with Email"}
                 </button>
             </form>
 
-            {inputError && <p className="error-message">{inputError}</p>}
             {errorMessage && <p className="error-message">{errorMessage}</p>}
 
             {/* Toggle between sign-in and sign-up */}
@@ -169,7 +157,8 @@ const Login: React.FC = () => {
                     onClick={() => {
                         setIsSigningUp(!isSigningUp);
                         setErrorMessage("");
-                        setInputError("");
+                        setEmailError("");
+                        setPasswordError("");
                     }}
                 >
                     {isSigningUp ? "Sign In" : "Sign Up"}


### PR DESCRIPTION
This PR fixes 2 things in sign-in page
- The form now provides better feedback to users in case of errors
- Code structure has been cleaned up for maintainability reducing unnecessary code
- Removed unnecessary usage of handleGoogleSignIn for the second time which has no effect on code
- Now we have 2 different fields to handle passwordError and emailError so now if there's an error in the email, only email will get red highlight or let's say the user has entered pw less than 8 words then only pw area will get highlighted red

Screenshot:
<img width="613" alt="Screenshot 2025-01-04 at 10 17 24 AM" src="https://github.com/user-attachments/assets/9209f62d-ee7d-4164-9fae-9054caf7462c" />

Another important change which this PR does is adding user to local storage with signInWithEmailAndPassword. So, this function now works correctly and the user is able to see the newly added uid in the queue.

Screenshot:
<img width="729" alt="image" src="https://github.com/user-attachments/assets/a0622fd8-433a-4cf2-aa7f-f71f852da6ac" />