### PR TITLE
Add TrackMetrics Endpoint and Format queueJoinTimes in API

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -26,6 +26,7 @@ const getTakenRoute = require('./routes/getTakenRoute');
 const currentStateRoute = require('./routes/currentStateRoute');
 const joinGameRoute = require('./routes/joinGameRoute');
 const advanceQueueRoute = require('./routes/advanceQueueRoute');
+const trackMetricsRoute = require('./routes/trackMetricsRoute');
 
 // Use imported routes
 app.use('/api', resetCourtsRoute);  // resetCourts endpoint
@@ -38,6 +39,7 @@ app.use('/api', getTakenRoute); // getTaken endpoint
 app.use('/api', currentStateRoute); // currentState endpoint
 app.use('/api', joinGameRoute); // DUMMY joinGame endpoint - REPLACE WITH ACTUAL CODE IN ROUTE FILE!
 app.use('/api', advanceQueueRoute);  // advanceQueue endpoint
+app.use('/api', trackMetricsRoute);  // trackMetrics endpoint
 
 // Default route
 app.get('/', (req, res) => {

--- a/backend/routes/advanceQueueRoute.js
+++ b/backend/routes/advanceQueueRoute.js
@@ -39,7 +39,8 @@ router.post('/advanceQueue', async (req, res) => {
                 activeStartTimes: locationData.activeStartTimes,
                 activeWaitingPlayers: locationData.activeWaitingPlayers,
                 queueFirebaseUIDs: locationData.queueFirebaseUIDs,
-                queueNicknames: locationData.queueNicknames
+                queueNicknames: locationData.queueNicknames,
+                queueJoinTimes: locationData.queueJoinTimes
             });
         });
 

--- a/backend/routes/currentStateRoute.js
+++ b/backend/routes/currentStateRoute.js
@@ -20,15 +20,32 @@ router.post('/currentState', async (req, res) => {
 
         // Access relevant arrays
         const locationData = locationSnapshot.data();
-        const { queueFirebaseUIDs, queueNicknames, activeFirebaseUIDs, activeNicknames } = locationData;
+        const { queueFirebaseUIDs, queueNicknames, activeFirebaseUIDs, activeNicknames, queueJoinTimes} = locationData;
+
+        // Format join times to a readable format
+        const formattedQueueJoinTimes = queueJoinTimes.map(time => {
+          if (time instanceof admin.firestore.Timestamp) {
+              return time.toDate().toLocaleString('en-US', { 
+                  year: 'numeric', 
+                  month: 'long', 
+                  day: 'numeric', 
+                  hour: '2-digit', 
+                  minute: '2-digit', 
+                  hour12: true 
+              });
+          }
+          return time; // Fallback for non-Timestamp values
+        });
 
         // Send response back to client with updated player arrays
         res.status(200).json({
           activeNicknames: activeNicknames,
           queueNicknames: queueNicknames,
           activeFirebaseUIDs: activeFirebaseUIDs,
-          queueFirebaseUIDs: queueFirebaseUIDs
+          queueFirebaseUIDs: queueFirebaseUIDs,
+          queueJoinTimes: formattedQueueJoinTimes
         });
+
 
     } catch (error) {
         console.error('Error in currentState endpoint: ', error);

--- a/backend/routes/dynamicBufferRoute.js
+++ b/backend/routes/dynamicBufferRoute.js
@@ -34,7 +34,8 @@ router.post('/dynamicBuffer', async (req, res) => {
                 activeStartTimes: locationData.activeStartTimes,
                 activeWaitingPlayers: locationData.activeWaitingPlayers,
                 queueFirebaseUIDs: locationData.queueFirebaseUIDs,
-                queueNicknames: locationData.queueNicknames
+                queueNicknames: locationData.queueNicknames,
+                queueJoinTimes: locationData.queueJoinTimes
             });
         });
 

--- a/backend/routes/endSessionRoute.js
+++ b/backend/routes/endSessionRoute.js
@@ -43,7 +43,8 @@ router.post('/endSession', async (req, res) => {
                 activeStartTimes: locationData.activeStartTimes,
                 activeWaitingPlayers: locationData.activeWaitingPlayers,
                 queueFirebaseUIDs: locationData.queueFirebaseUIDs,
-                queueNicknames: locationData.queueNicknames
+                queueNicknames: locationData.queueNicknames,
+                queueJoinTimes: locationData.queueJoinTimes
             });
         });
   

--- a/backend/routes/joinGameRoute.js
+++ b/backend/routes/joinGameRoute.js
@@ -28,16 +28,19 @@ router.post('/joinGame', async (req, res) => {
 
         // Access relevant arrays
         const locationData = locationSnapshot.data();
-        const { queueFirebaseUIDs, queueNicknames } = locationData;
+        const { queueFirebaseUIDs, queueNicknames, queueJoinTimes} = locationData;
 
         // Add player to end of queue
         queueFirebaseUIDs.push(firebaseUID);
         queueNicknames.push(nickname);
+        // Add timestamp for join time to queueJoinTimes array of thi format 2024-11-19T12:30:00Z
+        queueJoinTimes.push(new Date());
 
         // Write new data to Firestore
         await locationRef.update({
             queueFirebaseUIDs: queueFirebaseUIDs,
             queueNicknames: queueNicknames,
+            queueJoinTimes: queueJoinTimes,
         });
   
         res.status(200).json({ status: 'queue' });

--- a/backend/routes/leaveQueueRoute.js
+++ b/backend/routes/leaveQueueRoute.js
@@ -36,6 +36,7 @@ router.post('/leaveQueue', async (req, res) => {
             transaction.update(locationRef, {
                 queueFirebaseUIDs: locationData.queueFirebaseUIDs,
                 queueNicknames: locationData.queueNicknames,
+                queueJoinTimes: locationData.queueJoinTimes
             });
         });
 

--- a/backend/routes/trackMetricsRoute.js
+++ b/backend/routes/trackMetricsRoute.js
@@ -1,0 +1,74 @@
+const express = require('express');
+const router = express.Router();
+const admin = require('firebase-admin');
+
+// Track Metrics endpoint
+router.post('/trackMetrics', async (req, res) => {
+    try {
+        // Get the location from the request body and validate
+        const location = req.body.location;
+        if (!location) {
+            return res.status(400).json({ message: "Location is required" });
+        }
+
+        // Get the location document snapshot from Firestore
+        const locationRef = admin.firestore().collection('locations').doc(location);
+        const locationSnapshot = await locationRef.get();
+        if (!locationSnapshot.exists) {
+            return res.status(404).json({ message: 'Location not found.' });
+        }
+
+        // Access document data
+        const locationData = locationSnapshot.data();
+        const queueFirebaseUIDs = locationData.queueFirebaseUIDs || [];
+        const numberOfCourts = locationData.numberOfCourts || 0;
+        const activeStartTimes = locationData.activeStartTimes || [];
+        const queueJoinTimes = locationData.queueJoinTimes || [];
+        
+        // keep track of courts currently taken
+        const takenCourts = [];
+        const activePlayers = locationData.activeFirebaseUIDs;
+        activePlayers.forEach((player) => {
+        if (!player.startsWith('Empty')) {
+            takenCourts.push(activePlayers.indexOf(player) + 1);
+        }
+        });
+
+        // Calculate the metrics
+        const queueSize = queueFirebaseUIDs.length;
+        const fillRatio = (takenCourts.length / numberOfCourts) * 100;
+
+        // Get the current date and time for metrics
+        const now = new Date();
+        const dateKey = now.toISOString().split("T")[0]; // 'YYYY-MM-DD' (e.g., '2024-11-19')
+        const timeKey = now.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false }); // 'HH:mm' (e.g., '1:15')
+
+        // Prepare the metrics data to write
+        const metricsRef = admin.firestore()
+            .collection('metrics')
+            .doc(location) // Use the location name as document ID
+            .collection('locationMetrics') // Subcollection for daily metrics
+            .doc(dateKey); // Use current date as document ID
+
+        const metricsData = {
+            [timeKey]: { 
+                fillRatio, 
+                queueSize,
+            },
+            activeJoinTimes: admin.firestore.FieldValue.arrayUnion(...activeStartTimes),
+            queueJoinTimes: admin.firestore.FieldValue.arrayUnion(...queueJoinTimes)
+        };
+
+        // Use .set with merge: true to avoid overwriting existing data
+        await metricsRef.set(metricsData, { merge: true });
+
+        // Send a success response back to the client
+        res.status(200).json({ message: "Metrics tracked successfully." });
+
+    } catch (error) {
+        console.error("Error tracking metrics:", error);
+        res.status(500).json({ message: "Server error" });
+    }
+});
+
+module.exports = router;

--- a/backend/utils/advanceQueue.js
+++ b/backend/utils/advanceQueue.js
@@ -3,7 +3,7 @@ const dynamicBuffer = require('./dynamicBuffer'); // Import dynamicBuffer
 const createTimestamps = require('./createTimestamps');
 
 async function advanceQueue(locationData) {
-    const { activeFirebaseUIDs, activeNicknames, activeStartTimes, activeWaitingPlayers, queueFirebaseUIDs, queueNicknames } = locationData;
+    const { activeFirebaseUIDs, activeNicknames, activeStartTimes, activeWaitingPlayers, queueFirebaseUIDs, queueNicknames, queueJoinTimes} = locationData;
 
     // Create an array of adjusted timestamps
     const timestamps = await createTimestamps(activeFirebaseUIDs.length);
@@ -22,6 +22,7 @@ async function advanceQueue(locationData) {
             // Get UID and nickname of first player in the current queue
             const firstQueuePlayerUID = queueFirebaseUIDs.shift();
             const firstQueuePlayerNickname = queueNicknames.shift();
+            const firstQueueJoinTimes = queueJoinTimes.shift();
             
             // Update active data to reflect the new player
             activeFirebaseUIDs[i] = firstQueuePlayerUID; 

--- a/backend/utils/dynamicBuffer.js
+++ b/backend/utils/dynamicBuffer.js
@@ -2,7 +2,7 @@
 // const scheduleEndSession = require('./scheduleEndSession'); // Import scheduleEndSession 
 
 async function dynamicBuffer(locationData) {
-    const { activeFirebaseUIDs, activeNicknames, activeStartTimes, activeWaitingPlayers, queueFirebaseUIDs, queueNicknames } = locationData;
+    const { activeFirebaseUIDs, activeNicknames, activeStartTimes, activeWaitingPlayers, queueFirebaseUIDs, queueNicknames, queueJoinTimes} = locationData;
 
     // Count how many active players have someone waiting
     const numberWaitingPlayers = activeWaitingPlayers.filter(value => value === true).length;

--- a/backend/utils/leaveQueue.js
+++ b/backend/utils/leaveQueue.js
@@ -1,5 +1,5 @@
 async function leaveQueue(locationData, firebaseUID) {
-    const { queueFirebaseUIDs, queueNicknames } = locationData;
+    const { queueFirebaseUIDs, queueNicknames, queueJoinTimes} = locationData;
 
     // Check whether the player exists
     const playerIndex = queueFirebaseUIDs.indexOf(firebaseUID);
@@ -10,6 +10,7 @@ async function leaveQueue(locationData, firebaseUID) {
     // Update the relevant fields
     queueFirebaseUIDs.splice(playerIndex, 1);
     queueNicknames.splice(playerIndex, 1);
+    queueJoinTimes.splice(playerIndex, 1);
     return 200;
 }
 

--- a/backend/utils/resetSingleCourt.js
+++ b/backend/utils/resetSingleCourt.js
@@ -17,6 +17,7 @@ async function resetSingleCourt(locationRef, locationData, transaction) {
         activeWaitingPlayers: activeWaitingPlayers,
         queueFirebaseUIDs: [],
         queueNicknames: [],
+        queueJoinTimes: []
     });
 }
 


### PR DESCRIPTION
This PR introduces the following key updates:
1. **Queue Join Times Functionality**:
   - Adds a new `queueJoinTimes` field to the Firestore database for locations.
   - Formats code to adjust `queueJoinTimes` in already existing endpoints 
   
<img width="349" alt="Screenshot 2025-01-05 at 10 00 58 AM" src="https://github.com/user-attachments/assets/ae3fd9a0-f6d5-4627-952e-0a7e2e48e261" />


2. **/trackMetrics Endpoint Implementation**:
   - Creates a `/trackMetrics` endpoint to calculate and store location-specific metrics.
   - Metrics tracked:
     - **Queue Size**: Current length of the queue.
     - **Fill Ratio**: Percentage of courts currently occupied.
   - Stores metrics in a structured format using `YYYY-MM-DD` and `HH:mm` as document keys.
   - Uses Firestore’s `.set()` with `merge: true` to avoid overwriting existing data.
   
<img width="825" alt="Screenshot 2025-01-05 at 10 00 31 AM" src="https://github.com/user-attachments/assets/052614db-ce5a-4051-aef3-2c3c6f38fdf1" />

**Postman API response:** we need to input the location, as an output is as expected
<img width="851" alt="image" src="https://github.com/user-attachments/assets/f7b7e854-7e1c-4564-bd5c-382f6d41b3d0" />