### PR TITLE
Add unknowns functionality

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -143,6 +143,56 @@ export const sendWebNotification = async (locationName, firebaseUID, message, re
   }
 };
 
+export const getTaken = async (locationName, retries = 3, delay = 500) => {
+  try {
+    const response = await fetch(`${BACKEND_API}/api/getTaken`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        location: locationName,
+      }),
+    });
+    if (!response.ok) throw new Error('Failed to retrieve taken courts.');
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    if (retries > 0) {
+      console.log(`Retrying getTaken (${retries} retries left)...`);
+      await new Promise(res => setTimeout(res, delay)); // Exponential backoff
+      return await getTaken(locationName, retries - 1, delay * 2); // Retry logic
+    }
+    console.error("Error fetching taken courts:", error);
+    return null;
+  }
+};
+
+export const addUnknowns = async (locationName, courts, retries = 3, delay = 500) => {
+  try {
+    const response = await fetch(`${BACKEND_API}/api/addUnknowns`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        location: locationName,
+        occupiedCourts: courts,
+      }),
+    });
+    if (!response.ok) throw new Error('Failed to add unknowns.');
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    if (retries > 0) {
+      console.log(`Retrying addUnknowns (${retries} retries left)...`);
+      await new Promise(res => setTimeout(res, delay)); // Exponential backoff
+      return await addUnknowns(locationName, courts, retries - 1, delay * 2); // Retry logic
+    }
+    console.error("Error adding unknowns:", error);
+    return null;
+  }
+};
 
 // ** UTILITY FUNCTION TO CREATE FIRESTORE LISTENER **
 


### PR DESCRIPTION
Add functionality described below:

On the active view page, where we have the leave queue button, do the following:

Before we call the join game endpoint: Call the /getTaken endpoint. This returns an updateRequired boolean, a list of court numbers that should be taken, and the total number of courts.
If the update required is false, then do nothing. Otherwise:
Show 1 checkbox for each number from 1 to numberOfCourts (from /getTaken). Select the checkboxes for the court numbers you got from the /getTaken endpoint array.
Ask the user "Which courts are currently occupied?" and let them modify those checkboxes. Now, call the /addUnknowns endpoint with the selected numbers as a parameter. Ensure you have a confirmation popup.
Create a similar method in the utils/api.js file to call the /getTaken endpoint. Same for /addUnknowns
**As mentioned, this flow should take place BEFORE we call join game.

Use the generic version of the confirmation popup we have in active view.