### PR TITLE
Implement User Messaging Permission Page

### DIFF
--- a/frontend/firebase-messaging-sw.js
+++ b/frontend/firebase-messaging-sw.js
@@ -1,0 +1,8 @@
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('../firebase-messaging-sw.js')
+    .then(function (registration) {
+      console.log('Registration successful, scope is:', registration.scope);
+    }).catch(function (err) {
+      console.log('Service worker registration failed, error:', err);
+    });
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import NotFound from './pages/NotFound';
 import LocationSelection from './pages/LocationSelection/LocationSelection'
 import UserInfo from './pages/UserInfo/UserInfoForm';
 import SignIn from './pages/SignIn/SignIn';
+import MessagingPermission from './pages/MessagingPermission/MessagingPermission';
 import ActiveView from './pages/ActiveView/ActiveView';
 import JoinCourt from './pages/JoinCourt/JoinCourt';
 
@@ -24,6 +25,7 @@ function App() {
         <Route path="/user-info" element={<UserInfo />} />
         <Route path="/join-court" element={<JoinCourt />} />
         <Route path="/sign-in" element={<SignIn />} />
+        <Route path="/messaging-permission" element={<MessagingPermission />} />
         <Route path="/active-view" element={<ActiveView />} />
       </Routes>
     </LocalStorageProvider>

--- a/frontend/src/context/LocalStorageContext.tsx
+++ b/frontend/src/context/LocalStorageContext.tsx
@@ -5,6 +5,7 @@ const UserInfoEnum = {
   selectedLocation: "selectedLocation",
   firebaseUID: "firebaseUID",
   nickname: "nickname",
+  token: "token",
   addedToGame: "addedToGame",
   inQueue: "inQueue",
   playerData: "playerData",
@@ -22,6 +23,7 @@ export function LocalStorageProvider( { children } ) {
   const [selectedLocation, setSelectedLocation] = useState(localStorage.getItem(UserInfoEnum.selectedLocation) || '');
   const [firebaseUID, setFirebaseUID] = useState(localStorage.getItem(UserInfoEnum.firebaseUID) || '');
   const [nickname, setNickname] = useState(localStorage.getItem(UserInfoEnum.nickname) || '');
+  const [token, setToken] = useState(localStorage.getItem(UserInfoEnum.token) || 'NULL');
   const [addedToGame, setAddedToGame] = useState(localStorage.getItem(UserInfoEnum.addedToGame) === 'true' ? true : false);
   const [inQueue, setInQueue] = useState(localStorage.getItem(UserInfoEnum.inQueue) === 'true' ? true : false);
   const [playerData, setPlayerData] = useState(localStorage.getItem(UserInfoEnum.playerData) ? JSON.parse(localStorage.getItem(UserInfoEnum.playerData)!) : '');
@@ -33,6 +35,7 @@ export function LocalStorageProvider( { children } ) {
     const storedSelectedLocation = localStorage.getItem(UserInfoEnum.selectedLocation);
     const storedFirebaseUID = localStorage.getItem(UserInfoEnum.firebaseUID);
     const storedNickname = localStorage.getItem(UserInfoEnum.nickname);
+    const storedToken = localStorage.getItem(UserInfoEnum.token);
     const storedAddedToGame = localStorage.getItem(UserInfoEnum.addedToGame) === 'true';
     const storedInQueue = localStorage.getItem(UserInfoEnum.inQueue) === 'true';
     const storedPlayerData = localStorage.getItem(UserInfoEnum.playerData);
@@ -42,6 +45,7 @@ export function LocalStorageProvider( { children } ) {
     if (storedSelectedLocation) setSelectedLocation(storedSelectedLocation);
     if (storedFirebaseUID) setFirebaseUID(storedFirebaseUID);
     if (storedNickname) setNickname(storedNickname);
+    if (storedToken) setToken(storedToken);
     if (storedAddedToGame) setAddedToGame(storedAddedToGame);
     if (storedInQueue) setInQueue(storedInQueue);
     if (storedPlayerData) setPlayerData(storedPlayerData);
@@ -63,6 +67,11 @@ export function LocalStorageProvider( { children } ) {
   const updateNickname = (value: string) => {
     setNickname(value);
     localStorage.setItem(UserInfoEnum.nickname, value);
+  };
+
+  const updateToken = (value: string) => {
+    setToken(value);
+    localStorage.setItem(UserInfoEnum.token, value);
   };
 
   const updateAddedToGame = (value: boolean) => {
@@ -94,6 +103,7 @@ export function LocalStorageProvider( { children } ) {
     setSelectedLocation('');
     setFirebaseUID('');
     setNickname('');
+    setToken('NULL');
     setAddedToGame(false);
     setInQueue(false);
     setPlayerData({});
@@ -111,6 +121,8 @@ export function LocalStorageProvider( { children } ) {
         setFirebaseUID: updateFirebaseUID,
         nickname,
         setNickname: updateNickname,
+        token,
+        setToken: updateToken,
         addedToGame,
         setAddedToGame: updateAddedToGame,
         inQueue,

--- a/frontend/src/pages/ActiveView/ActiveView.tsx
+++ b/frontend/src/pages/ActiveView/ActiveView.tsx
@@ -11,6 +11,7 @@ const ActiveView: React.FC = () => {
   const location = context.selectedLocation;
   const firebaseUID = context.firebaseUID;
   const nickname = context.nickname;
+  const token = context.token;
 
   const [loading, setLoading] = useState<boolean>(true);  // Initially set loading to true
 
@@ -19,7 +20,6 @@ const ActiveView: React.FC = () => {
   const hasInitializedRef = useRef<boolean>(false);
 
   useEffect(() => {
-    console.log("Active view useEffect");
     if (!firebaseUID) {
       setTimeout(() => {}, 1000);  // 1-second timeout for UID to load
     }
@@ -39,7 +39,7 @@ const ActiveView: React.FC = () => {
     if (!addedToGame) {
       setLoading(true);
       try {
-        const { status } = await joinGame(location, nickname, firebaseUID); // Call to backend
+        const { status } = await joinGame(location, nickname, firebaseUID, token); // Call to backend
         context.setAddedToGame(true);
         context.setInQueue(status === 'queue' ? true : false);
       } catch (error) {

--- a/frontend/src/pages/ActiveView/CurrentState.tsx
+++ b/frontend/src/pages/ActiveView/CurrentState.tsx
@@ -28,7 +28,9 @@ const CurrentState: React.FC = () => {
 
   // Function to check cache and load data
   const checkAndLoadCachedData = () => {
-    const cachedPlayers = JSON.parse(context.playerData || '{}');
+    const cachedPlayers = typeof context.playerData === 'string' && context.playerData.trim() !== ''
+    ? JSON.parse(context.playerData)
+    : {};
     const cachedTimestamp = context.playerDataLastUpdateTime;
     const cacheAge = cachedTimestamp ? Date.now() - new Date(cachedTimestamp).getTime() : null;
     const isInQueue = context.inQueue === 'true';

--- a/frontend/src/pages/MessagingPermission/MessagingPermission.css
+++ b/frontend/src/pages/MessagingPermission/MessagingPermission.css
@@ -1,0 +1,98 @@
+.messaging-permission-main-container {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    align-items: center;
+}
+
+/* --- Styling for the header --- */
+.header {
+    position: sticky;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: 16vh;
+    border-radius: 0 0 24px 24px;
+    background-color: var(--main-color);
+}
+
+.header-title {
+    font-family: var(--font-family);
+    font-weight: var(--header1-font-weight);
+    font-size: calc(var(--header2-font-size) * 0.7);
+    line-height: 1.2rem;
+    margin: 0 40px;
+    color: white;
+}
+
+.header-title span {
+    font-weight: calc(var(--header1-font-weight) * 0.9);
+    font-size: calc(var(--header2-font-size) * 0.6);
+}
+
+/* ---------------------------- */
+
+.messaging-permission-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    bottom: 0;
+    height: 100%;
+    max-width: fit-content;
+    padding: 10px 12vw 40px 12vw;
+    margin: 20px 0 40px 0;
+}
+
+.messaging-permission-title {
+    font-family: var(--font-family);
+    font-size: var(--header1-font-size);
+    font-weight: var(--header2-font-weight);
+    color: var(--main-text-color);
+    text-align: center;
+    margin-bottom: 10px;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 25px;
+}
+
+.messaging-permission-form-label {
+    font-family: var(--font-family);
+    font-size: var(--paragraph-font-size);
+    font-weight: var(--key-info-font-weight);
+    color: var(--secondary-text-color);
+    margin: 10px 6px;
+    text-align: center;
+    width: 100%;
+    /* Full width for alignment */
+}
+
+.messaging-permission-form-button {
+    padding: 10px;
+    background-color: var(--main-color);
+    color: white;
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    font-family: var(--font-family);
+    font-size: var(--button-font-size);
+    font-weight: var(--button-font-size);
+    transition: background-color 0.3s ease, transform 0.2s ease;
+    /* width: calc(50% - 10px); */
+    width: 100%;
+    margin: 5px 0 0 0;
+    border: var(--main-color) 2px solid;
+}
+
+.hollow-button {
+    background-color: #fff;
+    color: var(--main-color);
+}
+
+.error-message {
+    margin-top: 10px;
+    color: #ff4d4d;
+    font-size: 0.9rem;
+}

--- a/frontend/src/pages/MessagingPermission/MessagingPermission.tsx
+++ b/frontend/src/pages/MessagingPermission/MessagingPermission.tsx
@@ -1,0 +1,61 @@
+import React, { useContext, useState } from "react";
+import { getMessaging, getToken } from 'firebase/messaging';
+import { useNavigate } from "react-router-dom";
+import "./MessagingPermission.css";
+
+import { LocalStorageContext } from "../../context/LocalStorageContext";
+
+const MessagingPermission: React.FC = () => {
+
+    const context = useContext(LocalStorageContext);
+
+    const navigate = useNavigate(); // Navigation hook for redirecting
+
+    const [errorMessage, setErrorMessage] = useState(""); // Error message display
+
+    const requestPermission = async () => {
+        try {
+            const messaging = getMessaging();
+            const permission = await Notification.requestPermission();
+            if (permission !== 'granted') {
+                setErrorMessage('Notification permission denied.');
+                return;
+            }
+
+            const vapidKey = 'BIn7HfgGhmz1NJ7T0SOYcxQC1MkNjRlwT4awKTSJp9yvruJFZxzShp4reOdk1kpeKO6CRI2d68F0X_Dr1zrhfSI';
+            const token = await getToken(messaging, { vapidKey });
+    
+            if (token) {
+                context.setToken(token);
+                setErrorMessage('');
+                navigate("/active-view");
+            } else {
+                setErrorMessage('Failed enabling notification permissions.');
+            }
+        } catch (error) {
+            setErrorMessage('Error allowing notification permissions.');
+        }
+    };
+
+    return (
+        <div className="messaging-permission-main-container">
+            <div className="header">
+                <h1 className="header-title"><span>Brampton</span><br />Tennis Queue</h1>
+            </div>
+            <div className="messaging-permission-container">
+                <h2 className="messaging-permission-title">Turn on notifications</h2>
+                <p className="messaging-permission-form-label">Enable notifications so you don't miss your court time.</p>
+                <button type="button" className="messaging-permission-form-button" onClick={requestPermission}>
+                    Allow
+                </button>
+                <button type="submit" className="messaging-permission-form-button hollow-button" onClick={() => navigate('/active-view')}>
+                    Skip
+                </button>
+
+                {errorMessage && <p className="error-message">{errorMessage}</p>}
+            </div>
+        </div>
+    );
+};
+
+export default MessagingPermission;

--- a/frontend/src/pages/SignIn/SignIn.tsx
+++ b/frontend/src/pages/SignIn/SignIn.tsx
@@ -41,7 +41,7 @@ const Login: React.FC = () => {
 
                 context.setFirebaseUID(user.uid); // Store user UID in local storage
                 setTimeout(() => {}, 1000); // Delay to ensure UID is stored before redirect
-                navigate("/active-view"); // Navigate to active view on success
+                navigate("/messaging-permission"); // Navigate to active view on success
             })
             .catch(() => {
                 setErrorMessage("Google sign-in failed. Please try again.");
@@ -58,7 +58,7 @@ const Login: React.FC = () => {
           
                 context.setFirebaseUID(user.uid); // Store user UID in local storage
                 setTimeout(() => {}, 1000);
-                navigate("/active-view");
+                navigate("/messaging-permission");
             }).catch((error) => {
                 setErrorMessage("X sign-in failed. Please try again.");
             });
@@ -107,7 +107,7 @@ const handleEmailAuth = (e: React.FormEvent) => {
             console.log("User UID:", user.uid); // This is the user's UID
             context.setFirebaseUID(user.uid); // Store the UID in localStorage if needed
             console.log("User:", user);
-            navigate("/active-view"); // Navigate to the next page
+            navigate("/messaging-permission"); // Navigate to the next page
         })
         // Handle Firebase errors if authentication fails
         .catch((error) => {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -60,7 +60,7 @@ export const endSession = async (locationName, firebaseUID, retries = 3, delay =
 };
 
 // Add player to game with /joinGame endpoint
-export const joinGame = async (locationName, nickname, firebaseUID, retries = 3, delay = 500) => {
+export const joinGame = async (locationName, nickname, firebaseUID, token, retries = 3, delay = 500) => {
   try {
     const response = await fetch(`${BACKEND_API}/api/joinGame`, {
       method: 'POST',
@@ -71,6 +71,7 @@ export const joinGame = async (locationName, nickname, firebaseUID, retries = 3,
         location: locationName,
         nickname: nickname,
         firebaseUID: firebaseUID,
+        fcmToken: token,
       }),
     });
     if (!response.ok) throw new Error('Failed to join game.');


### PR DESCRIPTION
This PR implements the page for getting permission from the user to allow for Firebase messaging. If the user declines or there is an error getting the token for messaging permissions, the token is saved as "NULL". 

- The FCM token is saved to the context in the local storage, and when a user joins the game/queue, it is updated in the database
- firebase-messaging-sw.js was added to enable users to give permissions for messaging
- Some browsers, such as a Private Window on Firefox, don't allow messaging, in which case "NULL" will be used

![Screenshot 2025-02-08 at 00-07-20 Vite React TS](https://github.com/user-attachments/assets/be36f72d-0798-4a30-b391-498089f478ef)

<img width="576" alt="Screenshot 2025-02-08 at 12 14 38 AM" src="https://github.com/user-attachments/assets/73e492ee-ff9c-4ad2-a900-561324766a23" />

