### PR TITLE
Updated AuthContext to redirect current users to active view.

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -2,6 +2,8 @@
 import React, { createContext, useState, useEffect, useContext } from 'react';
 import { getAuth, onAuthStateChanged, User } from "firebase/auth";
 import { LocalStorageContext } from './LocalStorageContext';
+import { fetchCurrentState } from '../utils/api';
+import { useNavigate } from 'react-router-dom';
 
 // Create interface for our context type
 interface AuthContextType {
@@ -22,6 +24,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   
   // Get LocalStorageContext
   const localStorage = useContext(LocalStorageContext);
+  const navigate = useNavigate();
+  //const CACHE_EXPIRY_THRESHOLD = 60 * 1000;  // 60 seconds
+  const CACHE_EXPIRY_THRESHOLD = 10 * 1000;  // For testing!
   
   if (!localStorage) {
     throw new Error('AuthProvider must be used within a LocalStorageProvider');
@@ -30,7 +35,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   // In AuthContext.tsx, modify the onAuthStateChanged callback
   useEffect(() => {
     const auth = getAuth();
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
       setCurrentUser(user || null);
       
       // Add console.log to debug
@@ -40,6 +45,44 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       if (user?.uid) {
         console.log("Setting Firebase UID in localStorage:", user.uid);
         localStorage.setFirebaseUID(user.uid);
+      }
+
+      // Check whether the user is part of the game and needs to be redirected back to active view
+      const selectedLocation = localStorage.selectedLocation;
+      const addedToGame = localStorage.addedToGame;
+      // Before redirecting, ensure the user, location and added flag are set, and we are not already in active view
+      if (user?.uid && selectedLocation && addedToGame && !window.location.href.includes('active-view')) {
+        try {
+          // Check whether the user exists in the current state of this location
+          const cachedTimestamp = localStorage.playerDataLastUpdateTime;
+          const cacheAge = cachedTimestamp ? Date.now() - new Date(cachedTimestamp).getTime() : null;
+          if (cacheAge && cacheAge < CACHE_EXPIRY_THRESHOLD) {
+            // Cache is valid, so we can use it
+            console.log("Using cached data");
+            const cachedData = localStorage.playerData;
+            if (cachedData) {
+              const parsedData = JSON.parse(cachedData);
+              if (parsedData.activeFirebaseUIDs.includes(user.uid) || parsedData.queueFirebaseUIDs.includes(user.uid)) {
+                // Redirect to active view
+                console.log("Redirecting to active view");
+                setLoading(false);
+                navigate('/active-view');
+              }
+            }
+          } else {
+            // Cache is missing or outdated, so fetch current state
+            console.log("Fetching current state");
+            const fetchedData = await fetchCurrentState(selectedLocation);
+            if (fetchedData.queueFirebaseUIDs.includes(user.uid) || fetchedData.activeFirebaseUIDs.includes(user.uid)) {
+              // Redirect to active view
+              console.log("Redirecting to active view");
+              setLoading(false);
+              navigate('/active-view');
+            }
+          }
+        } catch (error) {
+          console.error("Error fetching current state: ", error);
+        }
       }
       
       setLoading(false);

--- a/frontend/src/pages/ActiveView/ActiveView.tsx
+++ b/frontend/src/pages/ActiveView/ActiveView.tsx
@@ -115,6 +115,7 @@ const ActiveView: React.FC = () => {
         if (response) {
           context?.setAddedToGame(true);
           context?.setInQueue(true);
+          await new Promise((resolve) => setTimeout(resolve, 3500));  // Sleep to ensure database propogates first
         } else {
           throw new Error('Failed to join game');
         }


### PR DESCRIPTION
Previous Problem: Users can reach the active view page, go back to the home page (by changing the suffix of the url to /) and then join the game again using the same firebaseUID.

Fix: I updated the AuthContext to redirect current users to the active view page based on the following conditions:

- firebaseUID is set in local storage
- location is set in local storage
- addedToGame is set to true in local storage
- the user is currently NOT on the active view page

Effectively, whenever the user opens any page on the site and these conditions are met, we perform the following:

- In like manner to the CurrentState component, we check the cached data's firebaseUIDs. If the data is stale, we use the /currentState endpoint to get the new data.
- Once the data is retrieved, we check whether the user's firebaseUID exists in either the active or queue list. If so, we navigate to the active-view page.

It is difficult to recreate the results in the form of screenshots, but switch to this branch and do the following:

- Once you have joined the game (ex: you joined the queue), manually change the url to something like /user-info or just /.
- You can inspect the messages in the console, but you'll notice that the AuthContext now (either using cache or fetch API) will redirect you back to the active view page.