### PR TITLE
Skip the sign in page for logged in users, and solved join game loading bugs

### DIFF
--- a/frontend/src/pages/ActiveView/ActiveView.tsx
+++ b/frontend/src/pages/ActiveView/ActiveView.tsx
@@ -113,9 +113,9 @@ const ActiveView: React.FC = () => {
         console.log("Join game response:", response);
         
         if (response) {
+          await new Promise((resolve) => setTimeout(resolve, 2000));  // Sleep to ensure database propogates first
           context?.setAddedToGame(true);
           context?.setInQueue(true);
-          await new Promise((resolve) => setTimeout(resolve, 3500));  // Sleep to ensure database propogates first
         } else {
           throw new Error('Failed to join game');
         }

--- a/frontend/src/pages/ActiveView/CurrentState.tsx
+++ b/frontend/src/pages/ActiveView/CurrentState.tsx
@@ -145,6 +145,17 @@ const CurrentState: React.FC = () => {
   }, 300);
 
   useEffect(() => {
+    // Only run if the player was added to the game to avoid the bug
+    // where the component initially mounts for a split second before being hidden
+    // inside of the active view component
+    try {
+      if (!context.addedToGame) {
+        return;
+      }
+    } catch {
+      return;
+    }
+
     // On page load, check and load cached data
     checkAndLoadCachedData();
 

--- a/frontend/src/pages/SignIn/SignIn.tsx
+++ b/frontend/src/pages/SignIn/SignIn.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useState, useEffect } from "react";
 import { auth } from "../../firebase";
 import {
     signInWithPopup,
@@ -14,10 +14,12 @@ import googleIcon from "../../assets/google-icon.svg";
 import xIcon from "../../assets/x-icon.png";
 
 import { LocalStorageContext } from "../../context/LocalStorageContext";
+import { AuthContext } from "../../context/AuthContext";
 
 const Login: React.FC = () => {
 
     const context = useContext(LocalStorageContext);
+    const authContext = useContext(AuthContext);
     const twitterProvider = new TwitterAuthProvider() // Twitterv(X) authentication provider
     const googleProvider = new GoogleAuthProvider(); // Google authentication provider
 
@@ -30,6 +32,14 @@ const Login: React.FC = () => {
     const [passwordError, setPasswordError] = useState(""); // Password-specific error state
     
     const navigate = useNavigate(); // Navigation hook for redirecting
+
+    // Redirect if user is already authenticated
+    useEffect(() => {
+        if (authContext?.currentUser) {
+            context.setAddedToGame(false);  // Reset added to game status
+            navigate("/messaging-permission");
+        }
+    }, [authContext, navigate]);
 
     // Handle google-based authentication
     const handleGoogleSignIn = () => {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -212,6 +212,15 @@ export const subscribeToLocation = (location, updateState) => {
         return;
       }
 
+      // Check if the data is from the cache as this snapshot will be out of
+      // date and will trigger a premature shutdown of the listener causing
+      // the bug on load after joining the game
+      if (docSnapshot.metadata.fromCache) {
+        // Skip the update since the data is from the cache
+        console.log('Data is from cache, waiting for real-time data');
+        return;
+      }
+
       // Get document data and update the state
       const locationData = docSnapshot.data();
       updateState(locationData);


### PR DESCRIPTION
Added functionality to skip the sign in page for authenticated users, and solved the bugs for page load after joining the game.

For the sign in skip, I simply used the auth context to check if the currentUser existed. If so, set the addedToGame flag and redirect forward to the messaging-permission page. You can test this out by trying localhost on an incognito window.

For the bug on page load, there were 2 bugs I found. To begin, when we mount the active view component the current state component gets mounted for a couple milliseconds before being hidden away. This caused the useEffect to run and that version of the database did not have the new user present so this sets the inQueue flag to false - which shuts down all updates (the logic being that active players don't need updates). So, I added a check in the current state useEffect to only continue if the user has been added to the game.

The second bug is the firestore listener. Sometimes it will send you data that is cached. And this causes the same problem because the cached data will not have any reference of the new player who just joined so the inQueue gets set to false and the updates stop.

Now - HOPEFULLY LOL - we should be able to avoid those loading bugs!!!! 