### PR TITLE
Implement Account Page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import SignIn from './pages/SignIn/SignIn';
 import MessagingPermission from './pages/MessagingPermission/MessagingPermission';
 import ActiveView from './pages/ActiveView/ActiveView';
 import JoinCourt from './pages/JoinCourt/JoinCourt';
+import Account from './pages/Account/Account';
 
 // Import contexts
 import { LocalStorageProvider } from './context/LocalStorageContext';
@@ -29,6 +30,7 @@ function App() {
           <Route path="/join-court" element={<JoinCourt />} />
           <Route path="/sign-in" element={<SignIn />} />
           <Route path="/messaging-permission" element={<MessagingPermission />} />
+          <Route path="/account" element={<Account />} />
           <Route 
             path="/active-view" 
             element={

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { getAuth } from "firebase/auth";
+import { useNavigate } from 'react-router-dom';
+
+const Header = () => {
+    const navigate = useNavigate();
+    const { currentUser } = getAuth();
+
+  const handleTitleClick = () => {
+    navigate('/');
+  };
+
+  const handleAccountClick = () => {
+    if (currentUser) navigate('/account');
+  };
+    
+    return (
+    <div className="header">
+        <h1 className="header-title" onClick={handleTitleClick}>
+        <span>Brampton</span>
+        <br />
+        Tennis Queue
+        </h1>
+
+        {currentUser && (
+        <button className="header-title account-button" onClick={handleAccountClick}>
+          <span>Account</span>
+        </button>
+        )}
+    </div>
+    );
+};
+
+export default Header;

--- a/frontend/src/components/ResetPassword.tsx
+++ b/frontend/src/components/ResetPassword.tsx
@@ -5,6 +5,7 @@ import './ResetPassword.css';
 
 interface ResetPasswordProps {
   initialEmail?: string;
+  onAccountPage?: boolean;
   onClose?: () => void;
 }
 
@@ -13,7 +14,7 @@ interface ResetPasswordProps {
  * Provides a user-friendly interface for password reset
  */
 const ResetPassword: React.FC<ResetPasswordProps> = ({
-  initialEmail = '',
+  initialEmail = '', onAccountPage = false,
   onClose,
 }) => {
   const {
@@ -57,9 +58,15 @@ const ResetPassword: React.FC<ResetPasswordProps> = ({
     </div>
   );
 
+  const AccountButton: React.FC = () => (
+    <button type="button" className="account-form-button hollow-button" onClick={openResetModal}>
+      Reset Password
+    </button>
+  );
+
   // If modal isn't open, just show the button
   if (!isResetModalOpen) {
-    return <ResetButton />;
+    return !onAccountPage ? <ResetButton /> : <AccountButton />;
   }
 
   return (

--- a/frontend/src/context/LocalStorageContext.tsx
+++ b/frontend/src/context/LocalStorageContext.tsx
@@ -11,6 +11,7 @@ const UserInfoEnum = {
   playerData: "playerData",
   playerDataLastUpdateTime: "playerDataLastUpdateTime",
   expectedWaitTime: "expectedWaitTime",
+  recentLoginRequired: "recentLoginRequired"
 };
 
 // Add interface for children props
@@ -38,6 +39,8 @@ interface LocalStorageContextType {
   setPlayerDataLastUpdateTime: (value: string) => void;
   expectedWaitTime: number;
   setExpectedWaitTime: (value: number) => void;
+  recentLoginRequired: boolean;
+  setRecentLoginRequired: (value: boolean) => void;
   clear: () => void;
 }
 
@@ -55,6 +58,7 @@ export const LocalStorageProvider: React.FC<LocalStorageProviderProps> = ({ chil
   const [playerData, setPlayerData] = useState(localStorage.getItem(UserInfoEnum.playerData) ? JSON.parse(localStorage.getItem(UserInfoEnum.playerData)!) : '');
   const [playerDataLastUpdateTime, setPlayerDataLastUpdateTime] = useState(localStorage.getItem(UserInfoEnum.playerDataLastUpdateTime) || '');
   const [expectedWaitTime, setExpectedWaitTime] = useState(localStorage.getItem(UserInfoEnum.expectedWaitTime) ? Number(localStorage.getItem(UserInfoEnum.expectedWaitTime)!) : 0)
+  const [recentLoginRequired, setRecentLoginRequired] = useState(localStorage.getItem(UserInfoEnum.recentLoginRequired) === 'true' ? true : false);
 
   // Initialize state from localStorage
   useEffect(() => {
@@ -67,6 +71,7 @@ export const LocalStorageProvider: React.FC<LocalStorageProviderProps> = ({ chil
     const storedPlayerData = localStorage.getItem(UserInfoEnum.playerData);
     const storedPlayerDataLastUpdateTime = localStorage.getItem(UserInfoEnum.playerDataLastUpdateTime);
     const storedExpectedWaitTime = Number(localStorage.getItem(UserInfoEnum.expectedWaitTime));
+    const storedRecentLoginRequired = localStorage.getItem(UserInfoEnum.recentLoginRequired) === 'true';
 
     if (storedSelectedLocation) setSelectedLocation(storedSelectedLocation);
     if (storedFirebaseUID) setFirebaseUID(storedFirebaseUID);
@@ -77,6 +82,7 @@ export const LocalStorageProvider: React.FC<LocalStorageProviderProps> = ({ chil
     if (storedPlayerData) setPlayerData(storedPlayerData);
     if (storedPlayerDataLastUpdateTime) setPlayerDataLastUpdateTime(storedPlayerDataLastUpdateTime);
     if (storedExpectedWaitTime > 0) setExpectedWaitTime(storedExpectedWaitTime);
+    if (storedRecentLoginRequired) setRecentLoginRequired(storedRecentLoginRequired);
   }, []);
 
   // Helper functions to update both context and localStorage
@@ -125,6 +131,11 @@ export const LocalStorageProvider: React.FC<LocalStorageProviderProps> = ({ chil
     localStorage.setItem(UserInfoEnum.expectedWaitTime, value.toString());
   };
 
+  const updateRecentLoginRequired = (value: boolean) => {
+    setRecentLoginRequired(value);
+    localStorage.setItem(UserInfoEnum.recentLoginRequired, value.toString());
+  };
+
   const clear = () => {
     setSelectedLocation('');
     setFirebaseUID('');
@@ -135,6 +146,7 @@ export const LocalStorageProvider: React.FC<LocalStorageProviderProps> = ({ chil
     setPlayerData({});
     setPlayerDataLastUpdateTime('');
     setExpectedWaitTime(0);
+    setRecentLoginRequired(false);
     localStorage.clear();
   }
 
@@ -159,6 +171,8 @@ export const LocalStorageProvider: React.FC<LocalStorageProviderProps> = ({ chil
         setPlayerDataLastUpdateTime: updatePlayerDataLastUpdateTime,
         expectedWaitTime,
         setExpectedWaitTime: updateExpectedWaitTime,
+        recentLoginRequired,
+        setRecentLoginRequired: updateRecentLoginRequired,
         clear: clear,
       }}
     >

--- a/frontend/src/pages/Account/Account.css
+++ b/frontend/src/pages/Account/Account.css
@@ -1,4 +1,4 @@
-.main-container {
+.account-main-container {
     display: flex;
     flex-direction: column;
     height: 100vh;
@@ -47,7 +47,7 @@
     justify-content: center;
     bottom: 0;
     height: 100%;
-    min-width: fit-content;
+    width: fit-content;
     padding: 10px 12vw 40px 12vw;
     margin: 20px 0 40px 0;
 }

--- a/frontend/src/pages/Account/Account.css
+++ b/frontend/src/pages/Account/Account.css
@@ -1,4 +1,4 @@
-.messaging-permission-main-container {
+.main-container {
     display: flex;
     flex-direction: column;
     height: 100vh;
@@ -41,23 +41,23 @@
 
 /* ---------------------------- */
 
-.messaging-permission-container {
+.account-container {
     display: flex;
     flex-direction: column;
     justify-content: center;
     bottom: 0;
     height: 100%;
-    max-width: fit-content;
+    min-width: fit-content;
     padding: 10px 12vw 40px 12vw;
     margin: 20px 0 40px 0;
 }
 
-.messaging-permission-title {
+.account-title {
     font-family: var(--font-family);
     font-size: var(--header1-font-size);
     font-weight: var(--header2-font-weight);
     color: var(--main-text-color);
-    text-align: center;
+    text-align: left;
     margin-bottom: 10px;
 }
 
@@ -67,18 +67,27 @@
     margin-bottom: 25px;
 }
 
-.messaging-permission-form-label {
+.account-form-text {
     font-family: var(--font-family);
     font-size: var(--paragraph-font-size);
     font-weight: var(--key-info-font-weight);
     color: var(--secondary-text-color);
-    margin: 10px 6px;
-    text-align: center;
-    width: 100%;
-    /* Full width for alignment */
+    margin: 10px 0px;
 }
 
-.messaging-permission-form-button {
+.account-form-label {
+    font-weight: bold;
+    text-align: left;
+    float: left;
+    margin-right: 50px;
+}
+
+.account-form-value {
+    text-align: right;
+    float: right;
+}
+
+.account-form-button {
     padding: 10px;
     background-color: var(--main-color);
     color: white;
@@ -89,10 +98,14 @@
     font-size: var(--button-font-size);
     font-weight: var(--button-font-size);
     transition: background-color 0.3s ease, transform 0.2s ease;
-    /* width: calc(50% - 10px); */
     width: 100%;
     margin: 5px 0 0 0;
     border: var(--main-color) 2px solid;
+}
+
+.delete-button {
+    background-color: var(--secondary-color);
+    border: var(--secondary-color) 2px solid;
 }
 
 .hollow-button {

--- a/frontend/src/pages/Account/Account.tsx
+++ b/frontend/src/pages/Account/Account.tsx
@@ -85,7 +85,7 @@ const Account: React.FC = () => {
     }
 
     return (
-        <div className="main-container">
+        <div className="account-main-container">
             <Header />
             <div className="account-container">
                 <h2 className="account-title">Account</h2>

--- a/frontend/src/pages/Account/Account.tsx
+++ b/frontend/src/pages/Account/Account.tsx
@@ -1,0 +1,114 @@
+import React, { useContext, useState, useEffect } from "react";
+import { getAuth, deleteUser, sendPasswordResetEmail } from "firebase/auth";
+import { useNavigate } from "react-router-dom";
+import { fetchCurrentState } from '../../utils/api';
+import Header from '../../components/Header'; 
+import "./Account.css";
+
+import { LocalStorageContext } from "../../context/LocalStorageContext";
+
+const Account: React.FC = () => {
+
+    const context = useContext(LocalStorageContext);
+
+    const navigate = useNavigate(); // Navigation hook for redirecting
+    //const CACHE_EXPIRY_THRESHOLD = 60 * 1000;  // 60 seconds
+    const CACHE_EXPIRY_THRESHOLD = 10 * 1000;  // For testing!
+
+    // Redirect if user is not authenticated
+    useEffect(() => {
+        if (!context || !context.nickname || !context.firebaseUID || !context.selectedLocation) {
+            navigate("/");
+        }
+    }, [context, navigate]);
+
+    const [errorMessage, setErrorMessage] = useState(""); // Error message display
+
+    const deleteAccount = async () => {
+        const selectedLocation = context?.selectedLocation;
+        const auth = getAuth();
+        const user = auth.currentUser;
+        try {
+            // Check whether the user exists in the current state of this location
+            const cachedTimestamp = context?.playerDataLastUpdateTime;
+            const cacheAge = cachedTimestamp ? Date.now() - new Date(cachedTimestamp).getTime() : null;
+            if (!cacheAge || cacheAge >= CACHE_EXPIRY_THRESHOLD) {
+                // Cache is missing or outdated, so fetch current state
+                const fetchedData = await fetchCurrentState(selectedLocation);
+                if (fetchedData.activeFirebaseUIDs.includes(context?.firebaseUID)) {
+                    context?.setAddedToGame(true);
+                } else {
+                    context?.setAddedToGame(false);
+                }
+            }
+        } catch (error) {
+            console.error("Error fetching current state: ", error);
+        }
+        if (!context?.addedToGame) 
+            try {
+                if (user) {
+                    await deleteUser(user);
+                }
+                context?.clear();
+                navigate("/");
+            } catch (error: any) {
+                if (error.code == 'auth/requires-recent-login') {
+                    context?.setRecentLoginRequired(true);
+                    setErrorMessage("Requires recent sign in - redirecting...");
+                    setTimeout(() => {
+                        navigate('/sign-in');
+                    }, 3000);
+                } else {
+                    setErrorMessage("Error deleting account");
+                console.error("Error deleting account: ", error);
+                }
+            }
+         else {
+            setErrorMessage("Account cannot be deleted while in game");
+        }
+    };
+    
+    const resetPassword = async () => {
+        const auth = getAuth();
+        const user = auth.currentUser;
+        if (user && user.email) {
+            try {
+                sendPasswordResetEmail(auth, user.email)
+                alert("Password reset email sent!");
+            } catch (error) {
+                setErrorMessage("Error sending password reset email");
+                console.error("Error sending password reset email: ", error);
+            }
+        } else {
+            setErrorMessage("No email found");
+        }
+    }
+
+    return (
+        <div className="main-container">
+            <Header />
+            <div className="account-container">
+                <h2 className="account-title">Account</h2>
+                <div className="account-form-text">
+                    <span className="account-form-label">Nickname</span>
+                    <span className="account-form-value">{context?.nickname} </span>
+                </div>
+                <div className="account-form-text">
+                    <span className="account-form-label">Selected Location</span>
+                    <span className="account-form-value">{context?.selectedLocation} </span>
+                </div>
+
+                <button type="button" className="account-form-button hollow-button" onClick={resetPassword}>
+                    Reset Password
+                </button>
+                <button type="button" className="account-form-button delete-button" onClick={deleteAccount}>
+                    Delete Account
+                </button>
+
+                {errorMessage && <p className="error-message">{errorMessage}</p>}
+            </div>
+        </div>
+    );
+};
+
+export default Account;

--- a/frontend/src/pages/Account/Account.tsx
+++ b/frontend/src/pages/Account/Account.tsx
@@ -3,6 +3,8 @@ import { getAuth, deleteUser, sendPasswordResetEmail } from "firebase/auth";
 import { useNavigate } from "react-router-dom";
 import { fetchCurrentState } from '../../utils/api';
 import Header from '../../components/Header'; 
+import ResetPassword from "../../components/ResetPassword";
+
 import "./Account.css";
 
 import { LocalStorageContext } from "../../context/LocalStorageContext";
@@ -10,6 +12,8 @@ import { LocalStorageContext } from "../../context/LocalStorageContext";
 const Account: React.FC = () => {
 
     const context = useContext(LocalStorageContext);
+    const auth = getAuth();
+    const user = auth.currentUser;
 
     const navigate = useNavigate(); // Navigation hook for redirecting
     //const CACHE_EXPIRY_THRESHOLD = 60 * 1000;  // 60 seconds
@@ -97,10 +101,8 @@ const Account: React.FC = () => {
                     <span className="account-form-label">Selected Location</span>
                     <span className="account-form-value">{context?.selectedLocation} </span>
                 </div>
-
-                <button type="button" className="account-form-button hollow-button" onClick={resetPassword}>
-                    Reset Password
-                </button>
+                <ResetPassword initialEmail={user && user.email ? user.email : ''} onAccountPage={true}/>
+                
                 <button type="button" className="account-form-button delete-button" onClick={deleteAccount}>
                     Delete Account
                 </button>

--- a/frontend/src/pages/MessagingPermission/MessagingPermission.tsx
+++ b/frontend/src/pages/MessagingPermission/MessagingPermission.tsx
@@ -1,6 +1,8 @@
 import React, { useContext, useState } from "react";
 import { getMessaging, getToken } from 'firebase/messaging';
 import { useNavigate } from "react-router-dom";
+import Header from '../../components/Header'; 
+
 import "./MessagingPermission.css";
 
 import { LocalStorageContext } from "../../context/LocalStorageContext";
@@ -39,9 +41,7 @@ const MessagingPermission: React.FC = () => {
 
     return (
         <div className="messaging-permission-main-container">
-            <div className="header">
-                <h1 className="header-title"><span>Brampton</span><br />Tennis Queue</h1>
-            </div>
+            <Header />
             <div className="messaging-permission-container">
                 <h2 className="messaging-permission-title">Turn on notifications</h2>
                 <p className="messaging-permission-form-label">Enable notifications so you don't miss your court time.</p>

--- a/frontend/src/pages/SignIn/SignIn.css
+++ b/frontend/src/pages/SignIn/SignIn.css
@@ -22,12 +22,22 @@
   line-height: 1.2rem;
   margin: 0 40px;
   color: white;
+  cursor: pointer;
 }
 
 .header-title span {
   font-weight: calc(var(--header1-font-weight) * 0.9);
   font-size: calc(var(--header2-font-size) * 0.6);
 }
+
+.account-button {
+  color: white;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  margin-left: auto;
+}
+
 /* ---------------------------- */
 
 .login-container { 

--- a/frontend/src/pages/SignIn/SignIn.tsx
+++ b/frontend/src/pages/SignIn/SignIn.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from "react-router-dom";
 import "./SignIn.css";
 import googleIcon from "../../assets/google-icon.svg";
 import xIcon from "../../assets/x-icon.png";
+import Header from '../../components/Header'; 
 
 import { LocalStorageContext } from "../../context/LocalStorageContext";
 import { AuthProvider, AuthContext } from "../../context/AuthContext";
@@ -37,8 +38,9 @@ const Login: React.FC = () => {
 
     // Redirect if user is already authenticated
     useEffect(() => {
-        if (authContext?.currentUser) {
+        if (authContext?.currentUser && !context.recentLoginRequired) {
             context.setAddedToGame(false);  // Reset added to game status
+            context.setRecentLoginRequired(false);
             navigate("/messaging-permission");
         }
     }, [authContext, navigate]);
@@ -166,9 +168,7 @@ const handleEmailAuth = (e: React.FormEvent) => {
 
     return (
         <div className="main-container">
-            <div className="header">
-                <h1 className="header-title"><span>Brampton</span><br/>Tennis Queue</h1>
-            </div>
+            <Header />
             <div className="login-container">
                 <h2 className="login-title">{isSigningUp ? "Sign Up" : "Log In"}</h2>
 

--- a/frontend/src/pages/UserInfo/UserInfoForm.css
+++ b/frontend/src/pages/UserInfo/UserInfoForm.css
@@ -22,12 +22,22 @@
   line-height: 1.2rem;
   margin: 0 40px;
   color: white;
+  cursor: pointer;
 }
 
 .header-title span {
   font-weight: calc(var(--header1-font-weight) * 0.9);
   font-size: calc(var(--header2-font-size) * 0.6);
 }
+
+.account-button {
+  color: white;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  margin-left: auto;
+}
+
 /* ---------------------------- */
 
 /* Container styling for the form */

--- a/frontend/src/pages/UserInfo/UserInfoForm.tsx
+++ b/frontend/src/pages/UserInfo/UserInfoForm.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import './UserInfoForm.css';
 import ConfirmationModal from './ConfirmationModal';
 import { LocalStorageContext } from '../../context/LocalStorageContext';
+import Header from '../../components/Header'; 
 
 const UserInfo: React.FC = () => {
   const context = useContext(LocalStorageContext);
@@ -120,9 +121,7 @@ const UserInfo: React.FC = () => {
 
   return (
     <div className="main-container">
-      <div className="header">
-        <h1 className="header-title"><span>Brampton</span><br/>Tennis Queue</h1>
-      </div>
+      <Header />
       <div className="user-info-form">
         <h1 className="user-info-title">Choose Your Nickname<br/>& Group Size</h1>
         <form onSubmit={handleSubmit}>


### PR DESCRIPTION
This PR implements the account page where the user can delete their account or reset their password. As part of this PR, to get to the account page, a header component with a button to the account page that shows up if the user is logged in was added. In addition, you can also click on the brampton tennis queue title to get sent back to the starting page.

- Checks if cache has been recently updated before checking if user has been added to the game, and will fetch the current state if a long enough time has passed.
- Header component added to certain pages that links to the starting page and has a link to the account page, if the user is logged in.
- Added `recentLoginRequired` to the local storage context as if there is an attempt to delete an account after a long enough interval since the time of login, then it will be rejected. This stops the user from automatically being redirected to the messaging-permission page if they are already logged in and a new login is required to delete the account.
- Users can also reset their passwords through the account page using their email.

**Account Page**
![Screenshot 2025-03-07 at 20-17-46 Vite React TS](https://github.com/user-attachments/assets/5bcf0dcb-679c-469b-9e97-bbce029209e5)

**Before Deletion**
<img width="951" alt="Screenshot 2025-03-07 at 8 18 19 PM" src="https://github.com/user-attachments/assets/0f53b5ab-6795-4377-a52a-511adfa0c358" />

**After Deletion**
<img width="951" alt="Screenshot 2025-03-07 at 8 18 46 PM" src="https://github.com/user-attachments/assets/8f5e77b4-aad7-40d4-bb11-594858f6740a" />

**Password Reset Email**
<img width="951" alt="Screenshot 2025-03-07 at 8 25 20 PM" src="https://github.com/user-attachments/assets/d61798b8-708e-4229-859f-465b9f56a4fa" />

Note: [css updates](https://github.com/uoftblueprint/brampton-tennis-queue/pull/102) and [reset password hook](https://github.com/uoftblueprint/brampton-tennis-queue/pull/103) should be merged before this pr since it uses some of their components