### PR TITLE
verify email before join game

### DIFF
--- a/frontend/src/pages/ActiveView/ActiveView.tsx
+++ b/frontend/src/pages/ActiveView/ActiveView.tsx
@@ -8,6 +8,7 @@ import { addUnknowns } from '../../utils/api';
 import { LocalStorageContext } from '../../context/LocalStorageContext';
 import { AuthContext } from '../../context/AuthContext';
 import ConfirmationModal from './ConfirmationModal';
+import AlertModal from './AlertModal';
 
 const ActiveView: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
@@ -86,7 +87,6 @@ const ActiveView: React.FC = () => {
 
   const handleConfirmEmailAlert = () => {
     setShowEmailAlert(false);
-    setLoading(true);
     navigate('/sign-in');
   };
 
@@ -152,10 +152,9 @@ return (
   <div className="active-view">
     {/* Show Email Verification Alert */}
     {showEmailAlert && (
-        <ConfirmationModal
+        <AlertModal
           message="You must verify your email before joining the game."
-          onConfirm={handleConfirmEmailAlert}
-          onCancel={handleConfirmEmailAlert}
+          onClose={handleConfirmEmailAlert}
         />
       )}
 

--- a/frontend/src/pages/ActiveView/AlertModal.css
+++ b/frontend/src/pages/ActiveView/AlertModal.css
@@ -1,0 +1,58 @@
+/* Full-screen overlay for the modal */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent background */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+  }
+  
+  /* Modal content box */
+  .modal-content {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    width: 300px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+    text-align: center;
+  }
+  
+  /* Modal message */
+  .modal-content h2 {
+    margin-bottom: 10px;
+    font-size: 20px;
+    color: #333;
+  }
+  
+  .modal-content p {
+    font-size: 16px;
+    color: #555;
+    margin-bottom: 20px;
+  }
+  
+  /* Button for dismissing the alert */
+  .modal-ok-button {
+    padding: 10px 20px;
+    background-color: #007bff;
+    color: #fff;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-weight: bold;
+    transition: background-color 0.3s ease;
+  }
+  
+  .modal-ok-button:hover {
+    background-color: #0056b3;
+  }
+  
+  /* Center the OK button */
+  .modal-buttons {
+    display: flex;
+    justify-content: center;
+  }

--- a/frontend/src/pages/ActiveView/AlertModal.tsx
+++ b/frontend/src/pages/ActiveView/AlertModal.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import './AlertModal.css';
+
+interface AlertModalProps {
+  message: string;
+  onClose: () => void;
+}
+
+const AlertModal: React.FC<AlertModalProps> = ({ message, onClose }) => {
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content">
+        <h2>Alert</h2>
+        <p>{message}</p>
+        <div className="modal-buttons">
+          <button onClick={onClose} className="modal-ok-button">OK</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AlertModal;

--- a/frontend/src/pages/SignIn/SignIn.tsx
+++ b/frontend/src/pages/SignIn/SignIn.tsx
@@ -37,7 +37,7 @@ const Login: React.FC = () => {
 
     // Redirect if user is already authenticated
     useEffect(() => {
-        if (authContext?.currentUser) {
+        if (authContext?.currentUser && authContext?.currentUser.emailVerified) {
             context.setAddedToGame(false);  // Reset added to game status
             navigate("/messaging-permission");
         }


### PR DESCRIPTION
Once the ticket is completed to send people email verification, Firebase will set the "emailVerified" user attribute to true. You should modify the ActiveView component so that it checks currentUser.emailVerified is true - from the AuthContext's currentUser variable [React Context].

Concretely, on ActiveView,

If the email is not verified, then create an alert (using the confirmation modal template - with just "Ok") mentioning "You must verify your email before joining the game."
Then, navigate the user back to sign-in page and tell them to sign-in again.
Include detailed screenshots of the entire flow to validate the changes.
