### PR TITLE
Update CSS (Part 2): Active View, Join Court, and small bug fixes

### DIFF
--- a/frontend/src/pages/ActiveView/ActiveView.css
+++ b/frontend/src/pages/ActiveView/ActiveView.css
@@ -40,7 +40,7 @@
 }
   
 .court-selection p {
-    font-size: 16px;
+    font-size: var(--paragraph-font-size);
     color: #555;
     margin-bottom: 20px;
 }
@@ -49,15 +49,37 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    font-size: 16px;
+    font-size: var(--paragraph-font-size);
     color: #333;
     margin-bottom: 10px;
     cursor: pointer;
 }
-  
+
 .court-selection input[type="checkbox"] {
-    transform: scale(1.2);
+    appearance: none; /* Hide the default checkbox */
+    width: 22px;
+    height: 22px;
+    border: 2px solid var(--main-color);
+    border-radius: 4px;
+    display: inline-block;
+    position: relative;
     cursor: pointer;
+    transition: 0.3s;
+}
+
+.court-selection input[type="checkbox"]:checked {
+    background-color: var(--main-color);
+    border-color: var(--main-color);
+}
+
+.court-selection input[type="checkbox"]:checked::after {
+    content: '✔'; /* Unicode checkmark */
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 13px;
+    color: white;
 }
   
 .court-selection-buttons {
@@ -66,16 +88,21 @@
 }
   
 .court-confirm-button {
+    margin-top: 16px;
     padding: 10px 20px;
-    background-color: #007bff;
+    background-color: var(--main-color);
     color: #fff;
     border: none;
     border-radius: 5px;
     cursor: pointer;
-    font-weight: bold;
+    font-weight: var(--button-font-weight);
     transition: background-color 0.3s ease;
 }
   
 .court-confirm-button:hover {
-    background-color: #0056b3;
+    background-color: #fff; /* Darker on hover */
+    border: var(--main-color) 3px solid; /* Border on hover */
+    color: var(--main-color);
+    transition: 0.35s;
+    transform: translateY(-2px); /* Slight lift effect on hover */
 }

--- a/frontend/src/pages/ActiveView/ActiveView.css
+++ b/frontend/src/pages/ActiveView/ActiveView.css
@@ -6,8 +6,8 @@
 }
 
 .active-view p {
-    font-size: var(--key-info-font-size);
-    font-weight: var(--header2-font-weight);
+    font-size: var(--paragraph-info-font-size);
+    font-weight: var(--paragraph-font-weight);
     color: var(--main-text-color);
 }
 

--- a/frontend/src/pages/ActiveView/ConfirmationModal.css
+++ b/frontend/src/pages/ActiveView/ConfirmationModal.css
@@ -30,7 +30,7 @@
   }
   
   .modal-content p {
-    font-size: 16px;
+    font-size: var(--paragraph-font-size);
     color: #555;
     margin-bottom: 20px;
   }
@@ -43,7 +43,7 @@
   
   .modal-confirm-button {
     padding: 10px 20px;
-    background-color: #007bff;
+    background-color: var(--main-color);
     color: #fff;
     border: none;
     border-radius: 5px;
@@ -53,7 +53,11 @@
   }
   
   .modal-confirm-button:hover {
-    background-color: #0056b3;
+    background-color: #fff; /* Darker on hover */
+    border: var(--main-color) 3px solid; /* Border on hover */
+    color: var(--main-color);
+    transition: 0.35s;
+    transform: translateY(-2px); /* Slight lift effect on hover */
   }
   
   .modal-cancel-button {

--- a/frontend/src/pages/ActiveView/PlayerList.css
+++ b/frontend/src/pages/ActiveView/PlayerList.css
@@ -1,50 +1,44 @@
-@media (max-width: 768px) {
-  .courts {
-    flex-direction: column; /* Stack players vertically on small screens */
-  }
+.active-view, .current-state {
+  all: revert; /* Reset all CSS properties from active-view and current-state components */
+}
 
-  h2 {
-    font-size: 1.2em; /* Slightly smaller headings for compact screens */
-  }
+.players-list-container {
+  overflow-y: auto; /* Horizontal scrolling */
+  display: flex;
+  flex-direction: column;
+}
+
+/* Section titles */
+.players-list-title {
+  font-size: calc(var(--header2-font-size) * 0.9);
+  font-weight: var(--header1-font-weight);
+  color: var(--main-text-color);
+  margin-bottom: 15px;
+}
+
+/* Queue Players Section */
+.players-section {
+  padding: 10px 20px;
+  border-radius: 8px;
+}
+
+#queue-players {
+  margin-bottom: 40px;
+}
+
+#active-players {
+  margin-top: 10px;
 }
 
 .player-list {
-  padding: 20px;
-  font-family: Arial, sans-serif;
-}
-
-h2 {
-  font-size: 1.5em;
-  margin-bottom: 10px;
-  color: #333;
-}
-
-.active-players,
-.queue-players {
-  margin-bottom: 20px;
-}
-
-.courts {
   display: flex;
-  flex-wrap: wrap; /* Allow items to wrap into the next line */
-  gap: 10px; /* Space between rectangles */
-  background-color: #f8f9fa; /* Light background for the active players section */
-  padding: 10px;
-  border-radius: 8px;
+  flex-direction: column;
 }
 
-.queue-list {
-  display: flex;
-  flex-direction: column; /* Stack players vertically */
-  gap: 10px; /* Space between rectangles */
-  background-color: #f8f9fa; /* Light background for the queue players section */
-  padding: 10px;
-  border-radius: 8px;
-}
-
-p {
-  margin: 0;
-  font-size: 1em;
-  color: #666;
+/* Empty queue message */
+.empty-queue-message {
   text-align: center;
+  font-size: 1.1rem;
+  color: #666;
+  padding: 10px;
 }

--- a/frontend/src/pages/ActiveView/PlayerList.tsx
+++ b/frontend/src/pages/ActiveView/PlayerList.tsx
@@ -25,34 +25,48 @@ const PlayerList: React.FC<PlayerListProps> = ({
   };
 
   return (
-    <div className="player-list">
-      <div className="active-players">
-        <h2>Active Players</h2>
-        <div className="courts">
-          {activePlayers.map((nickname, index) => (
-            <RectangleWithOptions
-              key={index}
-              nickname={formatNickname(nickname)}
-              firebaseUID={activeFirebaseUIDs[index]}
-              inQueue={false}
-            />
-          ))}
-        </div>
+    <div className="players-list-container">
+      {/* Page heading */}
+      <div className="header">
+        <h2 className="header-title"><span>Brampton</span><br/>Tennis Queue</h2>
       </div>
-      <div className="queue-players">
-        <h2>Queue Players</h2>
-        <div className="queue-list">
-          {queuePlayers.length > 0 ? (
-            queuePlayers.map((nickname, index) => (
+      
+        {/* Active Players list */}
+      <div className="players-section" id="active-players">
+        <h2 className="players-list-title">Active Players</h2>
+
+        <div className="players-list">
+          {activePlayers.map((nickname, index) => (
+            <div key={index} className="player-card">
               <RectangleWithOptions
                 key={index}
                 nickname={formatNickname(nickname)}
-                firebaseUID={queueFirebaseUIDs[index]}
-                inQueue={true}
+                firebaseUID={activeFirebaseUIDs[index]}
+                inQueue={false}
               />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Queue Players list */}
+      <div className="players-section" id="queue-players">
+        <h2 className="players-list-title">Queue Players</h2>
+
+        <div className="players-list">
+          {queuePlayers.length > 0 ? (
+            queuePlayers.map((nickname, index) => (
+              <div key={index} className="player-card">
+                <RectangleWithOptions
+                  key={index}
+                  nickname={formatNickname(nickname)}
+                  firebaseUID={queueFirebaseUIDs[index]}
+                  inQueue={true}
+                />
+              </div>
             ))
           ) : (
-            <p>No players in the queue.</p>
+            <p className="empty-queue-message">No players in the queue.</p>
           )}
         </div>
       </div>

--- a/frontend/src/pages/ActiveView/RectangleWithOptions.css
+++ b/frontend/src/pages/ActiveView/RectangleWithOptions.css
@@ -1,15 +1,15 @@
 .rectangle-container {
+  justify-content: space-between;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 10px;
-  margin: 10px 0;
-  background-color: #f0f0f0;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  position: relative;
-  flex: 1 1 20%; /* Each rectangle will take up 20% of the available width */
+  background: #f9f9f9; /* Light background */
+  border-radius: 10px;
+  padding: 6px 16px;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
+  margin: 14px 0;
   box-sizing: border-box; /* Ensure padding is included in the width calculation */
+  flex: 1 1 20%; /* Each rectangle will take up 20% of the available width */
+
 }
 
 .dots-container {
@@ -24,18 +24,20 @@
 .dot {
   width: 4px;
   height: 4px;
-  background-color: #333;
+  background-color: #000;
   border-radius: 50%;
 }
 
 .action-button {
-  padding: 5px 10px;
+  padding: 6px 12px;
   background-color: var(--main-color);
   color: white;
   border: none;
   border-radius: 3px;
   cursor: pointer;
   transition: background-color 0.3s;
+  font-size: var(--paragraph-font-size);
+  font-weight: var(--paragraph-font-weight);
 }
 
 .action-button:hover {
@@ -48,15 +50,11 @@
 
 .action-button-container {
   display: flex;
-  position: absolute;
   flex-direction: column;
-  top: 100%;
-  right: 0;
-  margin-top: 1px;
   gap: 10px;
-  z-index: 9999; /* ensure it's always on top */
-  background-color: #F0F0F0;
-  padding: 10px 5px;
-  border: 1px solid black;
-  border-top: none;
+  z-index: 900; /* Ensure it's always on top */
+  background-color: #f9f9f9;
+  padding: 16px 12px;
+  border-radius: 10px;
+  box-shadow: 0px 3px 0px rgba(0, 0, 0, 0.1);
 }

--- a/frontend/src/pages/ActiveView/RectangleWithOptions.css
+++ b/frontend/src/pages/ActiveView/RectangleWithOptions.css
@@ -30,7 +30,7 @@
 
 .action-button {
   padding: 5px 10px;
-  background-color: #007bff;
+  background-color: var(--main-color);
   color: white;
   border: none;
   border-radius: 3px;
@@ -39,7 +39,11 @@
 }
 
 .action-button:hover {
-  background-color: #0056b3;
+  background-color: #fff; /* Darker on hover */
+  border: var(--main-color) 3px solid; /* Border on hover */
+  color: var(--main-color);
+  transition: 0.35s;
+  transform: translateY(-2px); /* Slight lift effect on hover */
 }
 
 .action-button-container {

--- a/frontend/src/pages/ActiveView/RectangleWithOptions.tsx
+++ b/frontend/src/pages/ActiveView/RectangleWithOptions.tsx
@@ -175,7 +175,7 @@ const RectangleWithOptions: React.FC<RectangleWithOptionsProps> = ({
 
   return (
     <div ref={rectangleRef} className="rectangle-container">
-      <span>{nickname}</span>
+      <p>{nickname}</p>
 
       {/* Display dots for toggling the button */}
       {!shouldIgnoreButton() && (
@@ -193,31 +193,38 @@ const RectangleWithOptions: React.FC<RectangleWithOptionsProps> = ({
 
           {showButton && (
             <>
-            {/* Conditionally render the button(s) */}
-            <div className="action-button-container">
-            {userOutOftime && (
-              [1, 2, 3].map((buttonNumber: number) => {
-                return (
-                  <button
-                    ref={buttonRef}
-                    className="action-button"
-                    onClick={() => handleButtonClick(buttonNumber)}
-                  >
-                    {determineButtonText(buttonNumber)}
-                  </button>
-                )})
-            )}
+              {/* Conditionally render the button(s) */}
+              <div 
+                className="action-button-container"
+                style={{
+                  position: "absolute",
+                  top: rectangleRef.current?.getBoundingClientRect().bottom + window.scrollY - 16 || 0,
+                  left: rectangleRef.current?.getBoundingClientRect().left || 0,
+                }}
+              >
+                {userOutOftime && (
+                  [1, 2, 3].map((buttonNumber: number) => {
+                    return (
+                      <button
+                        ref={buttonRef}
+                        className="action-button"
+                        onClick={() => handleButtonClick(buttonNumber)}
+                      >
+                        {determineButtonText(buttonNumber)}
+                      </button>
+                    )})
+                )}
 
-            {!userOutOftime && (
-                <button
-                  ref={buttonRef}
-                  className="action-button"
-                  onClick={() => handleButtonClick()}
-                >
-                  {determineButtonText()}
-                </button>
-            )}
-            </div>
+                {!userOutOftime && (
+                    <button
+                      ref={buttonRef}
+                      className="action-button"
+                      onClick={() => handleButtonClick()}
+                    >
+                      {determineButtonText()}
+                    </button>
+                )}
+              </div>
             </>
           )}
         </div>

--- a/frontend/src/pages/JoinCourt/JoinCourt.css
+++ b/frontend/src/pages/JoinCourt/JoinCourt.css
@@ -1,39 +1,149 @@
-.court-joiner {
-    margin: 0 auto;
-    text-align: left;
-    display: inline-block;
+.joiner-container {
+    display: flex;
+    flex-direction: column;
+    bottom: 0;
+    height: 100%;
+    padding: 10px 9vw 40px 9vw;
+    margin: 40px 0 40px 0;
 }
 
-.title, .subtext {
-    margin: 0;
+.joiner-header-title {
+    font-family: var(--font-family);
+    font-size: var(--header2-font-size);
+    font-weight: var(--header1-font-weight);
+    color: var(--main-text-color);
+    line-height: 1.55rem;
 }
 
 .wait-time {
-    margin-top: 30px;
     display: flex;
     flex-direction: row;
+    padding-bottom: 1rem;
+    border-bottom: 2px solid #d3d3d3;
 }
 
-.next-button {
-    float: right;
+.wait-time img {
+    width: 20px;
+    height: 20px;
+    margin-right: 10px;
 }
 
-.bottom-border {
-    border-bottom: 2px solid #D9D9D9;
-    width: 100%;
-    height: 5px;
-}
-
-.next-button:disabled {
-    background-color: darkgray;
-    transition: none;
-}
-
-.next-button:disabled:hover {
-    transform: none;
+.wait-time p {
+    font-size: var(--paragraph-font-size);
+    font-weight: var(--paragraph-font-weight);
+    color: var(--main-text-color);
 }
 
 .players-in-front {
+    margin-top: 30px;
+    margin-bottom: 30px;
+}
+
+.joiner-subtext {
+    font-size: var(--key-info-font-size);
+    font-weight: var(--key-info-font-weight);
+    color: var(--main-text-color);
+    margin-bottom: 20px;
+}
+
+.queue-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
     margin-top: 10px;
-    margin-bottom: 10px;
+}
+
+.queue-item {
+    display: flex;
+    align-items: center;
+    background: #f9f9f9; /* Light background */
+    border-radius: 10px;
+    padding: 10px 15px;
+    box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
+    transition: transform 0.2s ease-in-out;
+}
+
+.queue-item:hover {
+    transform: scale(1.03);
+}
+
+.queue-position {
+    font-size: 18px;
+    font-weight: bold;
+    color: white;
+    background: var(--main-color); /* Blue color for position */
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 15px;
+}
+
+.queue-info h4 {
+    font-size: 16px;
+    font-weight: bold;
+    color: #333;
+    margin: 0;
+}
+
+.queue-info p {
+    font-size: 14px;
+    color: #777;
+    margin: 0;
+}
+
+.empty-queue-list {
+    padding: 20px 0 20px 0;
+    border-radius: 10px;
+    padding: 10px 15px;
+    box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
+    background: #f9f9f9; /* Light background */
+}
+
+.empty-queue-message {
+    text-align: center;
+    font-size: var(--paragraph-font-size);
+    color: #2f2f2f;
+    font-weight: var(--paragraph-font-weight);
+    font-style: italic;
+    margin: 12px 0 10px 0;
+}
+
+
+.joiner-button {
+    width: 100%;
+    max-width: 300px;
+    padding: 12px 20px;
+    margin: 40px auto; /* Center the button */
+    background-color: var(--main-color); /* Primary color */
+    color: white;
+    font-size: var(--button-font-size);
+    font-weight: var(--button-font-weight);
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease-in-out;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+.joiner-button:hover {
+    background-color: #fff; /* Lighter color on hover */
+    border: var(--main-color) 3px solid; /* Border on hover */
+    color: var(--main-color);
+    transition: 0.35s;
+    transform: scale(1.05);
+}
+
+.joiner-button:disabled {
+    background-color: #d3d3d3; /* Grey for disabled state */
+    color: #888;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
 }

--- a/frontend/src/pages/JoinCourt/JoinCourt.css
+++ b/frontend/src/pages/JoinCourt/JoinCourt.css
@@ -18,8 +18,8 @@
 .wait-time {
     display: flex;
     flex-direction: row;
-    padding-bottom: 1rem;
     border-bottom: 2px solid #d3d3d3;
+    align-items: center;
 }
 
 .wait-time img {

--- a/frontend/src/pages/JoinCourt/JoinCourt.tsx
+++ b/frontend/src/pages/JoinCourt/JoinCourt.tsx
@@ -14,6 +14,7 @@ const JoinCourt: React.FC = () => {
   // State for whether all of the courts are full or not
   const [allCourtsFull, setAllCourtsFull] = useState(true);
   const [queueNicknames, setQueueNicknames] = useState([]);
+  // const [activeNicknames, setActiveNicknames] = useState([]); Can be implemented later when there's enough information about each court
 
   // Hook for navigating to the next page
   const navigate = useNavigate();
@@ -29,6 +30,7 @@ const JoinCourt: React.FC = () => {
         
         setAllCourtsFull(locationWaitData.allCourtsFull);
         setQueueNicknames(locationWaitData.queueNicknames);
+        // setActiveNicknames(locationWaitData.activeNicknames); Can be implemented later when there's enough information about each court
         context.setExpectedWaitTime(locationWaitData.expectedWaitTime);
     }
 
@@ -36,58 +38,81 @@ const JoinCourt: React.FC = () => {
   }, []);
 
   return (
-    <>
-    <div className="big-header">
+    <div className="main-container">
+      <div className="header">
         {/* Page heading */}
-        <h2 className="big-header-title"><span>Brampton</span><br/>Tennis Queue</h2>
+        <h2 className="header-title"><span>Brampton</span><br/>Tennis Queue</h2>
       </div>
 
-    <div className="court-joiner" style={{margin: "0 auto", display: "table"}}>
+      <div className="joiner-container">
 
-      {/* Page heading */}
-      <div className="heading">
-        <h2 className="title">{selectedLocation}</h2>
-        <h3 className="subtext">Tennis Courts</h3>
-      </div>
-      {/* Label for Selecting location */}
-      
-      <div className="wait-time">
-        <img src={clockIcon} alt="Clock Icon" className="button-icon" />
-        <p>Current queue time - {context.expectedWaitTime * 60} minutes</p>
-      </div>
-      <div className="bottom-border"></div>
+        {/* Page heading */}
+        <h1 className="joiner-header-title">{selectedLocation}</h1>
+        
+        {/* Wait time */}
+        <div className="wait-time">
+          <img src={clockIcon} alt="Clock Icon" className="button-icon" />
+          <p>Current queue time - {context.expectedWaitTime * 60} minutes</p>
+        </div>
 
-      <div className="players-in-front">
-        <h3 className="subtext">Players in front of you</h3>
+        {/* Active courts: can be implemented later when there's enough information about each court */}
+        {/* <div className="courts-carrousel">
+          {activeNicknames.map((nickname, index) => {
+            const [name, numPlaying] = (String(nickname)).split(' +'); // Splitting at " +"
 
-        <ol>
-          {queueNicknames.map((nickname, index) => {
-            return <li key={index}>{nickname}</li>
+            return (
+              <div key={index} className="court-card">
+                <h3>{name}</h3>
+                <p>{numPlaying ? `Playing with ${numPlaying} others` : "Solo player"}</p>
+              </div>
+            );
           })}
-        </ol>
+        </div> */}
+
+        <div className="players-in-front">
+          <h3 className="joiner-subtext">Players in front of you</h3>
+          {queueNicknames.length > 0 ? (
+            <div className="queue-list">
+              {queueNicknames.map((nickname, index) => {
+                const [name, numPlaying] = (String(nickname)).split(' +'); // Extract name & number
+
+                return (
+                  <div key={index} className="queue-item">
+                    <span className="queue-position">{index + 1}</span>
+                    <div className="queue-info">
+                      <h4>{name}</h4>
+                      {numPlaying && <p>+{numPlaying} others</p>}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="empty-queue-list">
+              <p className="empty-queue-message">The queue is empty.</p>
+            </div>
+          )}
+        </div>
+
+        {queueNicknames.length >= 5 ?
+          <button
+            disabled
+            className="joiner-button"
+          >
+            Queue full
+          </button>
+        :
+          <button 
+              className="joiner-button" 
+              onClick={handleNextPage}
+          >
+            {allCourtsFull ? "Join Queue" : "Start Playing"}
+          </button>
+        }
+
+        {/* Button for if courts are not full */}
       </div>
-
-      <div className="bottom-border"></div>
-
-    {queueNicknames.length >= 5 ?
-      <button
-        disabled
-        className="next-button">
-        Queue full
-      </button>
-     :
-      <button 
-          className="next-button" 
-          onClick={handleNextPage}
-        >
-        {allCourtsFull ? "Join Queue" : "Start Playing"}
-      </button>
-    }
-
-      {/* Button for if courts are not full */}
-      
     </div>
-    </>
   );
 };
 

--- a/frontend/src/pages/LocationSelection/LocationSelection.css
+++ b/frontend/src/pages/LocationSelection/LocationSelection.css
@@ -87,8 +87,8 @@
   text-align: center;
   font-family: var(--font-family);
   padding: 12px 0;
-  background-color: var(--main-color); /* Primary blue color */
-  border: none; /* Remove default border */
+  background-color: var(--main-color); /* Primary color */
+  border: none;
   border-radius: 0 0 8px 8px; /* Rounded corners */
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Subtle shadow effect */
   color: #fff; /* Text color */
@@ -101,15 +101,11 @@
 
 /* Hover effect */
 .next-button:hover {
-  background-color: #0056b3; /* Darker blue on hover */
+  background-color: #fff; /* Darker on hover */
+  border: var(--main-color) 3px solid; /* Border on hover */
+  color: var(--main-color);
+  transition: 0.35s;
   transform: translateY(-2px); /* Slight lift effect on hover */
-}
-
-/* Active effect */
-.next-button:active {
-  background-color: #004494; /* Even darker blue when active */
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2); /* Change shadow on click */
-  transform: translateY(1px); /* Slight depression effect on click */
 }
 
 @media screen and (max-width: 480px) {

--- a/frontend/src/pages/UserInfo/ConfirmationModal.css
+++ b/frontend/src/pages/UserInfo/ConfirmationModal.css
@@ -30,7 +30,7 @@
   }
   
   .modal-content p {
-    font-size: 16px;
+    font-size: var(--paragraph-font-size);
     color: #555;
     margin-bottom: 20px;
   }
@@ -43,17 +43,21 @@
   
   .modal-confirm-button {
     padding: 10px 20px;
-    background-color: #007bff;
+    background-color: var(--main-color);
     color: #fff;
     border: none;
     border-radius: 5px;
     cursor: pointer;
-    font-weight: bold;
+    font-weight: var(--button-font-weight);
     transition: background-color 0.3s ease;
   }
   
   .modal-confirm-button:hover {
-    background-color: #0056b3;
+    background-color: #fff; /* Darker on hover */
+    border: var(--main-color) 3px solid; /* Border on hover */
+    color: var(--main-color);
+    transition: 0.35s;
+    transform: translateY(-2px); /* Slight lift effect on hover */
   }
   
   .modal-cancel-button {
@@ -63,7 +67,7 @@
     border: none;
     border-radius: 5px;
     cursor: pointer;
-    font-weight: bold;
+    font-weight: var(--button-font-weight);
     transition: background-color 0.3s ease;
   }
   

--- a/frontend/src/styles/variables.css
+++ b/frontend/src/styles/variables.css
@@ -21,8 +21,11 @@
     --key-info-font-size: 1.2rem;
     --key-info-font-weight: 500;
     --paragraph-font-size: 1rem;
-    --paragraph-font-weight: 200;
+    --paragraph-font-weight: 300;
     --button-font-size: 1rem;
     --button-font-weight: 500;
     --header-font-size: 0.7rem;
+
+    /* Define global font family */
+    font-family: var(--font-family);
 }


### PR DESCRIPTION
This PR introduces the second batch of updates to the CSS, including:

- Active View updates: Modified Confirmation Modal with minor changes to ensure style consistency. The Player List and Rectangle With Options are now styled according to the design.
- Join Court updates: This page now has a fun queue design and is styled according to the design. There's still space to add an active court carousel in between the expected wait time and the queue display. However, it would require more information about the court, so it was commented out until further updates.

Active View with Player List and Rectangle With Options:
<img width="316" alt="Screenshot 2025-03-08 at 12 49 11" src="https://github.com/user-attachments/assets/4ebee920-3af6-4b55-9419-ccc035ecb927" />

Join Court view when there are players in the queue:
<img width="318" alt="Screenshot 2025-03-08 at 12 53 18" src="https://github.com/user-attachments/assets/8617f8e4-85dc-437d-b0ea-cecd4423a2f9" />

Join Court view when the queue is empty:
<img width="314" alt="Screenshot 2025-03-08 at 11 11 28" src="https://github.com/user-attachments/assets/33df231e-9422-4ad2-af5e-803d9ebe5e47" />

Confirmation Modal 1:
<img width="316" alt="Screenshot 2025-03-08 at 11 32 10" src="https://github.com/user-attachments/assets/eefdc8dc-137f-486b-be7b-4a8ffa3aaacd" />

Confirmation Modal 2:
<img width="317" alt="Screenshot 2025-03-08 at 12 50 33" src="https://github.com/user-attachments/assets/a4cf26e1-70d0-4ab5-a7e1-1763e5b173ec" />
