### PR TITLE
Update /leaveQueue to Erase Outdated Expiries

### DIFF
--- a/backend/routes/leaveQueueRoute.js
+++ b/backend/routes/leaveQueueRoute.js
@@ -38,6 +38,8 @@ router.post('/leaveQueue', async (req, res) => {
                 queueNicknames: locationData.queueNicknames,
                 queueJoinTimes: locationData.queueJoinTimes,
                 queueTokens: locationData.queueTokens,
+                activeNicknames: locationData.activeNicknames,
+                activeWaitingPlayers: locationData.activeWaitingPlayers
             });
         });
 

--- a/backend/utils/dynamicBuffer.js
+++ b/backend/utils/dynamicBuffer.js
@@ -2,7 +2,6 @@ const sendWebNotification = require('./sendNotification'); // Import sendWebNoti
 
 async function dynamicBuffer(locationData, location) {
     const { activeFirebaseUIDs, activeNicknames, activeStartTimes, activeWaitingPlayers, queueFirebaseUIDs, queueNicknames, queueJoinTimes } = locationData;
-
     // Count how many active players have someone waiting
     const numberWaitingPlayers = activeWaitingPlayers.filter(value => value === true).length;
 
@@ -56,10 +55,8 @@ async function dynamicBuffer(locationData, location) {
         
         // Update nickname
         const nickname = activeNicknames[player.index];
-        const spaceIndex = nickname.lastIndexOf(' ');
-        if (spaceIndex !== -1) {
-            activeNicknames[player.index] = nickname.substring(0, spaceIndex);
-        }
+
+        // Appends the expiry time to the end of the player nickname
         activeNicknames[player.index] += ` [${formattedTime}]`;
 
         // 📢 Immediately notify the player about their remaining time

--- a/backend/utils/leaveQueue.js
+++ b/backend/utils/leaveQueue.js
@@ -20,19 +20,12 @@ async function leaveQueue(locationData, firebaseUID) {
     queueJoinTimes.splice(playerIndex, 1);
     queueTokens.splice(playerIndex, 1);
 
-    // Merge activeStartTimes and activeWaitingPlayers as a tuple array
-    const dynamicPlayers = activeStartTimes.map((time, index) => [time, index, activeNicknames[index]]);
+    // Merge activeStartTimes and activeNicknames as a tuple array
+    let dynamicPlayers = activeStartTimes.map((time, index) => [time, index, activeNicknames[index]]);
 
-    // Remove all elements where the nickname contains a bracket
+    // Sort the active players by timestamps and filter out names without expiry bracket '[]'
+    dynamicPlayers = dynamicPlayers.filter(([time, index, name]) => name.includes('['));
     dynamicPlayers.sort((a, b) => a[0] - b[0]);
-    for (let i = 0; i < dynamicPlayers.length; i++) {
-        const [time, index, name] = dynamicPlayers[i];
-
-        if (!name.includes('[')) {
-            dynamicPlayers.splice(i, 1);
-            i--;
-        }
-    }
 
     // Assert to ensure the length of dynamicPlayers matches the count of true values in activeWaitingPlayers
     console.assert(dynamicPlayers.length === activeWaitingPlayers.filter(Boolean).length, "Mismatch between dynamicPlayers length and true count in activeWaitingPlayers");

--- a/backend/utils/leaveQueue.js
+++ b/backend/utils/leaveQueue.js
@@ -40,7 +40,7 @@ async function leaveQueue(locationData, firebaseUID) {
         if (activeNicknames[index]) {
             let bracketIndex = activeNicknames[index].indexOf('[');
             if (bracketIndex != -1) {
-                activeNicknames[index] = activeNicknames[index].substring(0, bracketIndex);
+                activeNicknames[index] = activeNicknames[index].substring(0, bracketIndex - 1);
             }
         }
     }

--- a/backend/utils/leaveQueue.js
+++ b/backend/utils/leaveQueue.js
@@ -1,6 +1,15 @@
-async function leaveQueue(locationData, firebaseUID) {
-    const { queueFirebaseUIDs, queueNicknames, queueJoinTimes, queueTokens } = locationData;
+import dynamicBuffer from "./dynamicBuffer";
 
+async function leaveQueue(locationData, firebaseUID) {
+    const { 
+        queueFirebaseUIDs, 
+        queueNicknames, 
+        queueJoinTimes, 
+        queueTokens,
+        activeStartTimes,
+        activeWaitingPlayers,
+        activeNicknames} = locationData;
+    
     // Check whether the player exists
     const playerIndex = queueFirebaseUIDs.indexOf(firebaseUID);
     if (playerIndex === -1) {
@@ -12,6 +21,35 @@ async function leaveQueue(locationData, firebaseUID) {
     queueNicknames.splice(playerIndex, 1);
     queueJoinTimes.splice(playerIndex, 1);
     queueTokens.splice(playerIndex, 1);
+
+    // Merge activeStartTimes and activeWaitingPlayers as a tuple array
+    const activePlayers = activeStartTimes.map((time, index) => [time, index]);
+
+    // Remove all elements where the nickname contains a bracket
+    activePlayers.sort((a, b) => a[0] - b[0]);
+    for (let i = 0; i < activePlayers.length; i++) {
+        const [time, index] = activePlayers[i];
+        if (activeNicknames[index].search('[') != -1) {
+            activeNicknames.splice(i, 1);
+        }
+    }
+
+    // Assert to ensure the length of activePlayers matches the count of true values in activeWaitingPlayers
+    console.assert(activePlayers.length === activeWaitingPlayers.filter(Boolean).length, "Mismatch between activePlayers length and true count in activeWaitingPlayers");
+
+    let remainingQueueLength = queueNicknames.length;
+
+    if (remainingQueueLength == activePlayers.length) {
+        return 200;
+    } else {
+        const [time, index] = activePlayers[activePlayers.length - 1];
+        activeWaitingPlayers[index] = false;
+        let bracketIndex = activeNicknames[index].indexOf('[');
+        if (bracketIndex != -1) {
+            activeNicknames[index] = activeNicknames[index].substring(0, bracketIndex);
+        }
+    }
+    
     return 200;
 }
 

--- a/backend/utils/leaveQueue.js
+++ b/backend/utils/leaveQueue.js
@@ -29,36 +29,28 @@ async function leaveQueue(locationData, firebaseUID) {
         const [time, index, name] = dynamicPlayers[i];
 
         if (!name.includes('[')) {
-console.log(name)
-console.log(name)
-            console.log(name)
             dynamicPlayers.splice(i, 1);
             i--;
         }
     }
 
     // Assert to ensure the length of dynamicPlayers matches the count of true values in activeWaitingPlayers
-    // console.assert(dynamicPlayers.length === activeWaitingPlayers.filter(Boolean).length, "Mismatch between dynamicPlayers length and true count in activeWaitingPlayers");
+    console.assert(dynamicPlayers.length === activeWaitingPlayers.filter(Boolean).length, "Mismatch between dynamicPlayers length and true count in activeWaitingPlayers");
 
     let remainingQueueLength = queueFirebaseUIDs.length;
 
-    console.log(remainingQueueLength == dynamicPlayers.length);
     if (remainingQueueLength == dynamicPlayers.length) {
         return 200;
     } else {
-        console.log(["here", dynamicPlayers])
         const [time, index, name] = dynamicPlayers[dynamicPlayers.length - 1];
         activeWaitingPlayers[index] = false;
-        console.log(activeNicknames[index]);
         if (activeNicknames[index]) {
             let bracketIndex = activeNicknames[index].indexOf('[');
-            console.log(bracketIndex);
             if (bracketIndex != -1) {
                 activeNicknames[index] = activeNicknames[index].substring(0, bracketIndex);
             }
         }
     }
-    console.log(activeNicknames)
     
     return 200;
 }

--- a/backend/utils/leaveQueue.js
+++ b/backend/utils/leaveQueue.js
@@ -1,5 +1,3 @@
-import dynamicBuffer from "./dynamicBuffer";
-
 async function leaveQueue(locationData, firebaseUID) {
     const { 
         queueFirebaseUIDs, 
@@ -23,32 +21,44 @@ async function leaveQueue(locationData, firebaseUID) {
     queueTokens.splice(playerIndex, 1);
 
     // Merge activeStartTimes and activeWaitingPlayers as a tuple array
-    const activePlayers = activeStartTimes.map((time, index) => [time, index]);
+    const dynamicPlayers = activeStartTimes.map((time, index) => [time, index, activeNicknames[index]]);
 
     // Remove all elements where the nickname contains a bracket
-    activePlayers.sort((a, b) => a[0] - b[0]);
-    for (let i = 0; i < activePlayers.length; i++) {
-        const [time, index] = activePlayers[i];
-        if (activeNicknames[index].search('[') != -1) {
-            activeNicknames.splice(i, 1);
+    dynamicPlayers.sort((a, b) => a[0] - b[0]);
+    for (let i = 0; i < dynamicPlayers.length; i++) {
+        const [time, index, name] = dynamicPlayers[i];
+
+        if (!name.includes('[')) {
+console.log(name)
+console.log(name)
+            console.log(name)
+            dynamicPlayers.splice(i, 1);
+            i--;
         }
     }
 
-    // Assert to ensure the length of activePlayers matches the count of true values in activeWaitingPlayers
-    console.assert(activePlayers.length === activeWaitingPlayers.filter(Boolean).length, "Mismatch between activePlayers length and true count in activeWaitingPlayers");
+    // Assert to ensure the length of dynamicPlayers matches the count of true values in activeWaitingPlayers
+    // console.assert(dynamicPlayers.length === activeWaitingPlayers.filter(Boolean).length, "Mismatch between dynamicPlayers length and true count in activeWaitingPlayers");
 
-    let remainingQueueLength = queueNicknames.length;
+    let remainingQueueLength = queueFirebaseUIDs.length;
 
-    if (remainingQueueLength == activePlayers.length) {
+    console.log(remainingQueueLength == dynamicPlayers.length);
+    if (remainingQueueLength == dynamicPlayers.length) {
         return 200;
     } else {
-        const [time, index] = activePlayers[activePlayers.length - 1];
+        console.log(["here", dynamicPlayers])
+        const [time, index, name] = dynamicPlayers[dynamicPlayers.length - 1];
         activeWaitingPlayers[index] = false;
-        let bracketIndex = activeNicknames[index].indexOf('[');
-        if (bracketIndex != -1) {
-            activeNicknames[index] = activeNicknames[index].substring(0, bracketIndex);
+        console.log(activeNicknames[index]);
+        if (activeNicknames[index]) {
+            let bracketIndex = activeNicknames[index].indexOf('[');
+            console.log(bracketIndex);
+            if (bracketIndex != -1) {
+                activeNicknames[index] = activeNicknames[index].substring(0, bracketIndex);
+            }
         }
     }
+    console.log(activeNicknames)
     
     return 200;
 }


### PR DESCRIPTION
This PR solves removes outdated player ending time when a user in the queue chooses to leave. 

**Changes:** 

Changes were made to `leaveQueue.js` API call such that when a player in the queue leaves, the dynamic buffer would remove the ending time for the player on the court that arrived the latest.

This is done via a new array named `dynamicPlayers` which contains the active players' start time, index, and nickname. 
Then, the active players without an end time are removed, and the rest of the list is sorted. 

The player that arrived the latest will have their nickname mutated and there will be no one waiting for their spot. 

**Test Case:**
 
Originally, we have four groups on court, and two groups in queue waiting. Thus, using dynamic buffer, the two groups that arrived the earliest got an end time. 

<img width="384" alt="image" src="https://github.com/user-attachments/assets/ba52ab22-ffe9-409f-ad05-9a458ce42e34" />

Then, if one of the queue groups are removed from the queue, leaveQueue API call will now remove the expiry time from the group with the latest arrival to the court. 

<img width="255" alt="image" src="https://github.com/user-attachments/assets/8344400f-66e6-4dae-891a-ee1ad688b5a1" />

**Edit:** 
Changed dynamicBuffer API call so that the group size info is retained when the expiry time is attached into their nickname. The function no longer searches for the index of the first space in the string. Instead, it just appends the expiry time after the group size.
